### PR TITLE
Refactor: Migrate Report Data Retrieval to Frappe Query Builder

### DIFF
--- a/nl_school/junior_school_customization/report/assessment_group_analysis/assessment_group_analysis.js
+++ b/nl_school/junior_school_customization/report/assessment_group_analysis/assessment_group_analysis.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2025, Navari and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Assessment Group Analysis"] = {
+  filters: [
+    {
+      fieldname: "company",
+      label: __("School"),
+      fieldtype: "Link",
+      options: "Company",
+      reqd: 1,
+    },
+    {
+      fieldname: "academic_year",
+      label: __("Academic Year"),
+      fieldtype: "Link",
+      options: "Academic Year",
+      reqd: 0,
+    },
+    {
+      fieldname: "academic_term",
+      label: "Academic Term",
+      fieldtype: "Link",
+      options: "Academic Term",
+      reqd: 0,
+    },
+    {
+      fieldname: "student_group",
+      label: __("Stream"),
+      fieldtype: "Link",
+      options: "Student Group",
+      reqd: 0,
+    },
+  ],
+};

--- a/nl_school/junior_school_customization/report/assessment_group_analysis/assessment_group_analysis.js
+++ b/nl_school/junior_school_customization/report/assessment_group_analysis/assessment_group_analysis.js
@@ -15,7 +15,7 @@ frappe.query_reports["Assessment Group Analysis"] = {
       label: __("Academic Year"),
       fieldtype: "Link",
       options: "Academic Year",
-      reqd: 0,
+      reqd: 1,
     },
     {
       fieldname: "academic_term",

--- a/nl_school/junior_school_customization/report/assessment_group_analysis/assessment_group_analysis.json
+++ b/nl_school/junior_school_customization/report/assessment_group_analysis/assessment_group_analysis.json
@@ -1,0 +1,35 @@
+{
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2025-06-09 09:20:27.077792",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letter_head": "Default",
+ "letterhead": null,
+ "modified": "2025-06-09 09:20:27.077792",
+ "modified_by": "Administrator",
+ "module": "Junior School Customization",
+ "name": "Assessment Group Analysis",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Assessment Result",
+ "report_name": "Assessment Group Analysis",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Student"
+  },
+  {
+   "role": "Academics User"
+  },
+  {
+   "role": "System Manager"
+  }
+ ],
+ "timeout": 0
+}

--- a/nl_school/junior_school_customization/report/assessment_group_analysis/assessment_group_analysis.py
+++ b/nl_school/junior_school_customization/report/assessment_group_analysis/assessment_group_analysis.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2025, Navari and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+
+
+def execute(filters: dict | None = None):
+    columns = get_columns(filters)
+    data = get_data(filters)
+    return columns, data
+
+
+def get_columns(filters: dict) -> list[dict]:
+    columns = [
+        {"label": _("Metric"), "fieldname": "metric", "fieldtype": "Data", "width": 100}
+    ]
+
+    courses = frappe.get_all(
+        "Assessment Result",
+        distinct=True,
+        fields=["course"],
+        order_by="course asc",
+    )
+
+    for course in courses:
+        course_name = course["course"]
+        safe_fieldname = course_name.lower().replace(" ", "_").replace("-", "_")
+
+        columns.append(
+            {
+                "label": _(course_name),
+                "fieldname": safe_fieldname,
+                "fieldtype": "Data",
+                "width": 170,
+            }
+        )
+
+    return columns
+
+
+def get_data(filters: dict) -> list[dict]:
+    conditions = get_conditions(filters)
+
+    results = frappe.get_all(
+        "Assessment Result",
+        filters=conditions,
+        fields=[
+            "course",
+            "SUM(total_score) as total_score",
+            "AVG(total_score) as mean",
+            "MAX(total_score) as max_score",
+            "MIN(total_score) as min_score",
+            "grade",
+        ],
+        group_by="course",
+        order_by="course desc",
+    )
+
+    if not results:
+        return []
+
+    course_lookup = {row["course"]: row for row in results}
+
+    courses = frappe.get_all(
+        "Assessment Result",
+        distinct=True,
+        fields=["course"],
+        filters=conditions,
+        order_by="course",
+    )
+
+    metrics = [
+        {"label": "Total Score", "field": "total_score"},
+        {"label": "Mean Score", "field": "mean"},
+        {"label": "Grade", "field": "grade"},
+        {"label": "Max Score", "field": "max_score"},
+        {"label": "Min Score", "field": "min_score"},
+    ]
+
+    data = []
+
+    for metric in metrics:
+        row = {"metric": metric["label"]}
+
+        for course in courses:
+            course_name = course["course"]
+            safe_fieldname = course_name.lower().replace(" ", "_").replace("-", "_")
+
+            if course_name in course_lookup:
+                value = course_lookup[course_name].get(metric["field"])
+                if metric["field"] == "grade":
+                    row[safe_fieldname] = str(value) if value else ""
+                else:
+                    row[safe_fieldname] = (
+                        f"{float(value):.1f}" if value is not None else "0.0"
+                    )
+            else:
+                row[safe_fieldname] = ""
+
+        data.append(row)
+
+    return data
+
+
+def get_conditions(filters: dict) -> dict:
+    conditions = {}
+    if filters.get("company"):
+        conditions["company"] = filters["company"]
+    if filters.get("academic_year"):
+        conditions["academic_year"] = filters["academic_year"]
+    if filters.get("academic_term"):
+        conditions["academic_term"] = filters["academic_term"]
+    if filters.get("student_group"):
+        conditions["student_group"] = filters["student_group"]
+
+    return conditions

--- a/nl_school/junior_school_customization/report/assessment_group_analysis/assessment_group_analysis.py
+++ b/nl_school/junior_school_customization/report/assessment_group_analysis/assessment_group_analysis.py
@@ -3,25 +3,33 @@
 
 import frappe
 from frappe import _
-
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Sum, Avg, Max, Min
 
 def execute(filters: dict | None = None):
     columns = get_columns(filters)
     data = get_data(filters)
     return columns, data
 
-
 def get_columns(filters: dict) -> list[dict]:
     columns = [
         {"label": _("Metric"), "fieldname": "metric", "fieldtype": "Data", "width": 100}
     ]
 
-    courses = frappe.get_all(
-        "Assessment Result",
-        distinct=True,
-        fields=["course"],
-        order_by="course asc",
+    AssessmentResult = DocType("Assessment Result")
+
+    conditions = get_conditions(filters)
+    query = (
+        frappe.qb.from_(AssessmentResult)
+        .select(AssessmentResult.course)
+        .distinct()
+        .orderby(AssessmentResult.course)
     )
+
+    for field, value in conditions.items():
+        query = query.where(AssessmentResult[field] == value)
+
+    courses = query.run(as_dict=True)
 
     for course in courses:
         course_name = course["course"]
@@ -38,37 +46,43 @@ def get_columns(filters: dict) -> list[dict]:
 
     return columns
 
-
 def get_data(filters: dict) -> list[dict]:
+    AssessmentResult = DocType("Assessment Result")
     conditions = get_conditions(filters)
 
-    results = frappe.get_all(
-        "Assessment Result",
-        filters=conditions,
-        fields=[
-            "course",
-            "SUM(total_score) as total_score",
-            "AVG(total_score) as mean",
-            "MAX(total_score) as max_score",
-            "MIN(total_score) as min_score",
-            "grade",
-        ],
-        group_by="course",
-        order_by="course desc",
+    query = (
+        frappe.qb.from_(AssessmentResult)
+        .select(
+            AssessmentResult.course,
+            Sum(AssessmentResult.total_score).as_("total_score"),
+            Avg(AssessmentResult.total_score).as_("mean"),
+            Max(AssessmentResult.total_score).as_("max_score"),
+            Min(AssessmentResult.total_score).as_("min_score"),
+            AssessmentResult.grade,
+        )
+        .groupby(AssessmentResult.course)
     )
+
+    for field, value in conditions.items():
+        query = query.where(AssessmentResult[field] == value)
+
+    results = query.run(as_dict=True)
 
     if not results:
         return []
 
     course_lookup = {row["course"]: row for row in results}
 
-    courses = frappe.get_all(
-        "Assessment Result",
-        distinct=True,
-        fields=["course"],
-        filters=conditions,
-        order_by="course",
+    course_query = (
+        frappe.qb.from_(AssessmentResult)
+        .select(AssessmentResult.course)
+        .distinct()
+        .orderby(AssessmentResult.course)
     )
+    for field, value in conditions.items():
+        course_query = course_query.where(AssessmentResult[field] == value)
+
+    courses = course_query.run(as_dict=True)
 
     metrics = [
         {"label": "Total Score", "field": "total_score"},
@@ -92,16 +106,13 @@ def get_data(filters: dict) -> list[dict]:
                 if metric["field"] == "grade":
                     row[safe_fieldname] = str(value) if value else ""
                 else:
-                    row[safe_fieldname] = (
-                        f"{float(value):.1f}" if value is not None else "0.0"
-                    )
+                    row[safe_fieldname] = f"{float(value):.1f}" if value is not None else "0.0"
             else:
                 row[safe_fieldname] = ""
 
         data.append(row)
 
     return data
-
 
 def get_conditions(filters: dict) -> dict:
     conditions = {}
@@ -113,5 +124,4 @@ def get_conditions(filters: dict) -> dict:
         conditions["academic_term"] = filters["academic_term"]
     if filters.get("student_group"):
         conditions["student_group"] = filters["student_group"]
-
     return conditions


### PR DESCRIPTION
This PR refactors the report logic to use the Frappe Query Builder instead of `frappe.get_all()`. This enhances readability, performance, and maintainability while preserving the original functionality of generating course-based assessment metrics.

---

#### ✅ Changes Implemented

- Replaced all `frappe.get_all()` calls with query builder equivalents using `frappe.qb` and `DocType`.
- Dynamic course column generation now uses `distinct()` from the query builder.
- Aggregation metrics (`SUM`, `AVG`, `MAX`, `MIN`) are now calculated using query builder functions (`Sum`, `Avg`, etc.).
- Applied filters dynamically with `.where(...)` conditions.
- Ensured column and data consistency by reusing filtered course queries.
- Retained support for filters such as:
  - `company`
  - `academic_year`
  - `academic_term`
  - `student_group`

---