### PR TITLE
feat: add Most Improved Students report

### DIFF
--- a/nl_school/junior_school_customization/report/most_improved_students/most_improved_students.js
+++ b/nl_school/junior_school_customization/report/most_improved_students/most_improved_students.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2025, Navari and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Most Improved Students"] = {
+  filters: [
+    {
+      fieldname: "company",
+      label: __("School"),
+      fieldtype: "Link",
+      options: "Company",
+      reqd: 1,
+    },
+    {
+      fieldname: "current_year",
+      label: __("Year"),
+      fieldtype: "Link",
+      options: "Academic Year",
+      reqd: 1,
+      default: frappe.defaults.get_default("academic_year"),
+    },
+    {
+      fieldname: "current_term",
+      label: __("Current Term"),
+      fieldtype: "Link",
+      options: "Academic Term",
+      reqd: 1,
+    },
+    {
+      fieldname: "compare_term",
+      label: __("Compare Term"),
+      fieldtype: "Link",
+      options: "Academic Term",
+      reqd: 1,
+    },
+  ],
+
+  formatter: function (value, row, column, data, default_formatter) {
+    if (column.fieldname === "deviation") {
+      let formatted_value = default_formatter(value, row, column, data);
+      if (value < 0) {
+        return `<span style="color: red; font-weight: bold;">${formatted_value}</span>`;
+      } else {
+        return `<span style="color: green; font-weight: bold;">${formatted_value}</span>`;
+      }
+    }
+    return default_formatter(value, row, column, data);
+  },
+};

--- a/nl_school/junior_school_customization/report/most_improved_students/most_improved_students.json
+++ b/nl_school/junior_school_customization/report/most_improved_students/most_improved_students.json
@@ -1,0 +1,35 @@
+{
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2025-06-24 13:43:16.672709",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letter_head": "Default",
+ "letterhead": null,
+ "modified": "2025-06-24 13:43:16.672709",
+ "modified_by": "Administrator",
+ "module": "Junior School Customization",
+ "name": "Most Improved Students",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Assessment Result",
+ "report_name": "Most Improved Students",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Student"
+  },
+  {
+   "role": "Academics User"
+  },
+  {
+   "role": "System Manager"
+  }
+ ],
+ "timeout": 0
+}

--- a/nl_school/junior_school_customization/report/most_improved_students/most_improved_students.py
+++ b/nl_school/junior_school_customization/report/most_improved_students/most_improved_students.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2025, Navari and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Avg
+from collections import defaultdict
+
+
+def execute(filters=None):
+    columns = get_columns()
+    data = get_data(filters)
+    return columns, data
+
+
+def get_columns():
+    return [
+        {
+            "label": _("Student"),
+            "fieldname": "student",
+            "fieldtype": "Link",
+            "options": "Student",
+            "width": 180,
+        },
+        {
+            "label": _("Student Group"),
+            "fieldname": "student_group",
+            "fieldtype": "Link",
+            "options": "Student Group",
+            "width": 150,
+        },
+        {
+            "label": _("current_term" + " Avg"),
+            "fieldname": "current_term_avg",
+            "fieldtype": "Float",
+            "width": 120,
+            "precision": 1,
+        },
+        {
+            "label": _("compare_term" + " Avg"),
+            "fieldname": "compare_term_avg",
+            "fieldtype": "Float",
+            "width": 120,
+            "precision": 1,
+        },
+        {
+            "label": _("Deviation"),
+            "fieldname": "deviation",
+            "fieldtype": "Float",
+            "width": 120,
+            "precision": 1,
+        },
+    ]
+
+
+def get_data(filters):
+    compare_term = filters.get("compare_term")
+    current_term = filters.get("current_term")
+    company = filters.get("company")
+    academic_year = filters.get("current_year")
+
+    if not compare_term or not current_term:
+        return []
+
+    AssessmentResult = DocType("Assessment Result")
+
+    query = (
+        frappe.qb.from_(AssessmentResult)
+        .select(
+            AssessmentResult.student,
+            AssessmentResult.student_name,
+            AssessmentResult.student_group,
+            AssessmentResult.academic_term,
+            Avg(AssessmentResult.total_score).as_("avg_score"),
+        )
+        .where(AssessmentResult.academic_term.isin([compare_term, current_term]))
+        .groupby(
+            AssessmentResult.student,
+            AssessmentResult.student_group,
+            AssessmentResult.academic_term,
+        )
+    )
+
+    if company:
+        query = query.where(AssessmentResult.company == company)
+
+    if academic_year:
+        query = query.where(AssessmentResult.academic_year == academic_year)
+
+    results = query.run(as_dict=True)
+
+    pivot = defaultdict(dict)
+
+    for row in results:
+        student = row["student"]
+        pivot[student]["student_name"] = row["student_name"]
+        pivot[student]["student_group"] = row["student_group"]
+        pivot[student][row["academic_term"]] = row["avg_score"]
+
+    data = []
+
+    for student, row in pivot.items():
+        term1_avg = row.get(compare_term, 0.0)
+        term2_avg = row.get(current_term, 0.0)
+        deviation = term2_avg - term1_avg
+
+        data.append(
+            {
+                "student": row["student_name"],
+                "student_group": row["student_group"],
+                "current_term_avg": round(term2_avg, 2),
+                "compare_term_avg": round(term1_avg, 2),
+                "deviation": round(deviation, 2),
+            }
+        )
+    top_per_group = {}
+    for row in data:
+        group = row["student_group"]
+        current_best = top_per_group.get(group)
+        if not current_best or row["deviation"] > current_best["deviation"]:
+            top_per_group[group] = row
+    data = sorted(top_per_group.values(), key=lambda x: x["deviation"], reverse=True)
+
+    return data

--- a/nl_school/junior_school_customization/report/most_improved_students/most_improved_students.py
+++ b/nl_school/junior_school_customization/report/most_improved_students/most_improved_students.py
@@ -31,17 +31,17 @@ def get_columns():
             "width": 150,
         },
         {
-            "label": _("current_term" + " Avg"),
+            "label": _("Current Term" + " Avg"),
             "fieldname": "current_term_avg",
             "fieldtype": "Float",
-            "width": 120,
+            "width": 200,
             "precision": 1,
         },
         {
-            "label": _("compare_term" + " Avg"),
+            "label": _("Compare Term" + " Avg"),
             "fieldname": "compare_term_avg",
             "fieldtype": "Float",
-            "width": 120,
+            "width": 200,
             "precision": 1,
         },
         {


### PR DESCRIPTION
# Add Most Improved Students Report

## Overview
This PR introduces a new custom report, Most Improved Students, designed to help schools identify students who have shown the improvement between two academic terms. The report compares average assessment scores for each student across a selected "compare term" and "current term," calculates the deviation, and highlights the top improver in each student group.

## Features
- **Term Comparison**: Compare student performance between any two academic terms
- **Filtered Results**: Shows the single most improved student from each student group
- **Visual Indicators**: Color-coded deviation values (green for positive improvement, red for decline)
- **Comprehensive Filters**: Filter by school (company), academic year, current term, and comparison term
- **Performance Metrics**: Displays average scores for both terms and the improvement deviation

## Technical Implementation
- Uses Frappe Query Builder for efficient database queries
- Implements pivot table logic to aggregate assessment results by student and term
- Groups results by student group and selects top performer per group
- Custom formatter for enhanced visual presentation of deviation values

![redacted-image (1)](https://github.com/user-attachments/assets/1f2ac498-063c-4384-8992-98cb671732c9)
