### PR TITLE
feat: add class filter

### DIFF
--- a/nl_school/junior_school_customization/report/academic_performance_summary/academic_performance_summary.js
+++ b/nl_school/junior_school_customization/report/academic_performance_summary/academic_performance_summary.js
@@ -25,6 +25,13 @@ frappe.query_reports["Academic Performance Summary"] = {
       reqd: 1,
     },
     {
+      fieldname: "program",
+      label: __("Class"),
+      fieldtype: "Link",
+      options: "Program",
+      reqd: 0,
+    },
+    {
       fieldname: "student_group",
       label: __("Stream"),
       fieldtype: "Link",

--- a/nl_school/junior_school_customization/report/academic_performance_summary/academic_performance_summary.py
+++ b/nl_school/junior_school_customization/report/academic_performance_summary/academic_performance_summary.py
@@ -135,6 +135,8 @@ def get_conditions(filters: dict) -> dict:
         conditions["grading_scale"] = filters["grading_scale"]
     if filters.get("student_group"):
         conditions["student_group"] = filters["student_group"]
+    if filters.get("program"):
+        conditions["program"] = filters["program"]
     return conditions
 
 


### PR DESCRIPTION
## Overview
This enhancement adds class-level filtering capability to the Academic Performance Summary report, allowing users to filter results by academic class (e.g., Grade 2) while maintaining the existing stream filtering functionality.

## Problem Statement
The current report only allows filtering by:
- School
- Academic Year
- Term
- Stream (Student Group)
- Grading Scale

Users need the ability to filter by academic class (Program/grade level) to:
1. View performance data for an entire grade level
2. Narrow down to specific streams within a grade level
3. Compare performance across different classes

Previous:
![image](https://github.com/user-attachments/assets/df523920-dbb3-4605-96c9-ded924ab07bc)


Current :
![image](https://github.com/user-attachments/assets/a44d41e1-0689-4ac6-a04a-05b9094ba24a)
