### PR TITLE
Added New Workspace for Junior School Module

### DIFF
--- a/nl_school/junior_school_customization/workspace/junior_school/junior_school.json
+++ b/nl_school/junior_school_customization/workspace/junior_school/junior_school.json
@@ -1,0 +1,220 @@
+{
+ "charts": [
+  {
+   "chart_name": "Class Enrollment Trend",
+   "label": "Class Enrollment Trend"
+  }
+ ],
+ "content": "[{\"id\":\"3xRrHXm32F\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Junior School</span>\",\"col\":12}},{\"id\":\"bWDk5If37I\",\"type\":\"chart\",\"data\":{\"chart_name\":\"Class Enrollment Trend\",\"col\":12}},{\"id\":\"Hkm2pHj20D\",\"type\":\"number_card\",\"data\":{\"number_card_name\":\"Closed Assessment Plans\",\"col\":4}},{\"id\":\"sMCW_38DRY\",\"type\":\"number_card\",\"data\":{\"number_card_name\":\"Open Assessment Plans\",\"col\":4}},{\"id\":\"BksRHW_Oki\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Shortcuts</b></span>\",\"col\":12}},{\"id\":\"AOgjF_tSLq\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"School\",\"col\":3}},{\"id\":\"6A5Nxo-QvK\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Timetable Generator\",\"col\":3}},{\"id\":\"44HyUw5H6_\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Timetable Generation Result\",\"col\":3}},{\"id\":\"XcDOk5l7y5\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"School Timetable\",\"col\":3}},{\"id\":\"W_bweq20hb\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"pDXjZ5-yoV\",\"type\":\"card\",\"data\":{\"card_name\":\"Tools\",\"col\":4}},{\"id\":\"y84R1HRSzU\",\"type\":\"card\",\"data\":{\"card_name\":\"Reports\",\"col\":4}},{\"id\":\"cl0MqeKqWV\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Dashboards</b></span>\",\"col\":12}},{\"id\":\"ydLENSvWtn\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Student Overview \",\"col\":3}}]",
+ "creation": "2025-07-22 11:34:13.106766",
+ "custom_blocks": [],
+ "docstatus": 0,
+ "doctype": "Workspace",
+ "for_user": "",
+ "hide_custom": 0,
+ "icon": "organization",
+ "idx": 0,
+ "indicator_color": "green",
+ "is_hidden": 0,
+ "label": "Junior School",
+ "links": [
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Tools",
+   "link_count": 4,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Enhanced Program Enrollment Tool",
+   "link_count": 0,
+   "link_to": "Enhanced Program Enrollment Tool",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Enhanced Student Attendance Tool",
+   "link_count": 0,
+   "link_to": "Enhanced Student Attendance Tool",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Subject Scheduling Tool",
+   "link_count": 0,
+   "link_to": "Subject Scheduling Tool",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Student Report Generation Tool",
+   "link_count": 0,
+   "link_to": "Student Report Generation Tool",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Reports",
+   "link_count": 8,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Average Performance per Stream",
+   "link_count": 0,
+   "link_to": "Average Performance per Stream",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Analysis Report",
+   "link_count": 0,
+   "link_to": "Analysis Report",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Annual Performance Comparison",
+   "link_count": 0,
+   "link_to": "Annual Performance Comparison",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Departmental Analysis Report",
+   "link_count": 0,
+   "link_to": "Departmental Analysis Report",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Assessment Group Analysis",
+   "link_count": 0,
+   "link_to": "Assessment Group Analysis",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Most Improved Students",
+   "link_count": 0,
+   "link_to": "Most Improved Students",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Academic Performance Summary",
+   "link_count": 0,
+   "link_to": "Academic Performance Summary",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 1,
+   "label": "Stream Wise Performance",
+   "link_count": 0,
+   "link_to": "Stream Wise Performance",
+   "link_type": "Report",
+   "onboard": 0,
+   "type": "Link"
+  }
+ ],
+ "modified": "2025-07-22 12:43:09.183669",
+ "modified_by": "Administrator",
+ "module": "Junior School Customization",
+ "name": "Junior School",
+ "number_cards": [
+  {
+   "label": "Closed Assessment Plans",
+   "number_card_name": "Closed Assessment Plans"
+  },
+  {
+   "label": "Open Assessment Plans",
+   "number_card_name": "Open Assessment Plans"
+  }
+ ],
+ "owner": "Administrator",
+ "parent_page": "",
+ "public": 1,
+ "quick_lists": [],
+ "roles": [],
+ "sequence_id": 49.0,
+ "shortcuts": [
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Student Overview ",
+   "link_to": "Student Overview",
+   "type": "Dashboard"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "School",
+   "link_to": "Company",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Timetable Generator",
+   "link_to": "Timetable Generator",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Timetable Generation Result",
+   "link_to": "Timetable Generation Result",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "School Timetable",
+   "link_to": "school-timetable",
+   "type": "Page"
+  }
+ ],
+ "title": "Junior School"
+}


### PR DESCRIPTION

This PR introduces a custom workspace titled **"Junior School"** under the *Junior School Customization* module. The workspace is designed to provide quick access to key dashboards, reports, charts, and shortcuts relevant to the Junior School operations.

**Summary of Changes**:

* Added **Class Enrollment Trend** chart for visualizing enrollment data.
* Included **Number Cards**:

  * Closed Assessment Plans
  * Open Assessment Plans
* Added **Shortcuts** for quick navigation to:

  * Student Overview (Dashboard)
  * School
  * Timetable Generator
  * Timetable Generation Result
  * School Timetable
* Added **Cards** section for:

  * Tools (Program Enrollment Tool, Attendance Tool, Scheduling Tool, Report Generator)
  * Reports (with links to key performance and analysis reports)
* Structured headers and spacers to organize the workspace layout.
* Made the workspace **public** for easier access to all users.
<img width="937" height="877" alt="image" src="https://github.com/user-attachments/assets/51f5d611-1016-4dbb-ab81-0c3484b9d162" />

