### PR TITLE
 'Sessions' Doctype for Mental Health Wellbeing Tracking

### DIFF
--- a/nl_school/junior_school_customization/doctype/session/session.js
+++ b/nl_school/junior_school_customization/doctype/session/session.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Navari and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Session", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/nl_school/junior_school_customization/doctype/session/session.json
+++ b/nl_school/junior_school_customization/doctype/session/session.json
@@ -1,0 +1,183 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-07-25 12:31:08.904051",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "school",
+  "grade",
+  "stream",
+  "column_break_ituu",
+  "year",
+  "term",
+  "cohort",
+  "session_type_section",
+  "type",
+  "student",
+  "student_name",
+  "column_break_pjvr",
+  "topic",
+  "sub_topic",
+  "no_students_trained",
+  "case_history",
+  "case_management",
+  "next_steps"
+ ],
+ "fields": [
+  {
+   "fieldname": "school",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "School",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_ituu",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "year",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Year",
+   "options": "Academic Year",
+   "reqd": 1
+  },
+  {
+   "fieldname": "term",
+   "fieldtype": "Link",
+   "label": "Term",
+   "options": "Academic Term",
+   "reqd": 1
+  },
+  {
+   "fieldname": "cohort",
+   "fieldtype": "Data",
+   "label": "Cohort",
+   "read_only": 1
+  },
+  {
+   "fieldname": "session_type_section",
+   "fieldtype": "Section Break",
+   "label": "Session Type"
+  },
+  {
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "label": "Type",
+   "options": "Group Session\nIndividual Session",
+   "reqd": 1
+  },
+  {
+   "fieldname": "topic",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_standard_filter": 1,
+   "label": "Topic",
+   "options": "Course",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.type === \"Group Session\";",
+   "fieldname": "no_students_trained",
+   "fieldtype": "Int",
+   "label": "No Students Trained"
+  },
+  {
+   "fieldname": "grade",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Grade",
+   "options": "Program",
+   "reqd": 1
+  },
+  {
+   "fieldname": "stream",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Stream",
+   "options": "Student Group",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_pjvr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.type === \"Group Session\";",
+   "fieldname": "sub_topic",
+   "fieldtype": "Select",
+   "label": "Sub Topic"
+  },
+  {
+   "depends_on": "eval:doc.type===\"Individual Session\";",
+   "fieldname": "case_history",
+   "fieldtype": "Small Text",
+   "label": "Case History",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.type===\"Individual Session\";",
+   "fieldname": "student",
+   "fieldtype": "Link",
+   "label": "Student",
+   "options": "Student",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "student.student_name",
+   "fieldname": "student_name",
+   "fieldtype": "Data",
+   "label": "Student Name",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.type===\"Individual Session\";",
+   "fieldname": "next_steps",
+   "fieldtype": "Small Text",
+   "label": "Next Steps",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.type===\"Individual Session\";",
+   "fieldname": "case_management",
+   "fieldtype": "Small Text",
+   "label": "Case Management",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-07-25 14:46:50.617792",
+ "modified_by": "Administrator",
+ "module": "Junior School Customization",
+ "name": "Session",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/nl_school/junior_school_customization/doctype/session/session.json
+++ b/nl_school/junior_school_customization/doctype/session/session.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:SESS-{YYYY}-{type}-{####}",
  "creation": "2025-07-25 12:31:08.904051",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -122,15 +123,15 @@
    "fieldname": "case_history",
    "fieldtype": "Small Text",
    "label": "Case History",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.type===\"Individual Session\";"
   },
   {
    "depends_on": "eval:doc.type===\"Individual Session\";",
    "fieldname": "student",
    "fieldtype": "Link",
    "label": "Student",
-   "options": "Student",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.type===\"Individual Session\";",
+   "options": "Student"
   },
   {
    "fetch_from": "student.student_name",
@@ -144,23 +145,24 @@
    "fieldname": "next_steps",
    "fieldtype": "Small Text",
    "label": "Next Steps",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.type===\"Individual Session\";"
   },
   {
    "depends_on": "eval:doc.type===\"Individual Session\";",
    "fieldname": "case_management",
    "fieldtype": "Small Text",
    "label": "Case Management",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.type===\"Individual Session\";"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-25 14:46:50.617792",
+ "modified": "2025-07-25 16:29:25.357635",
  "modified_by": "Administrator",
  "module": "Junior School Customization",
  "name": "Session",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {

--- a/nl_school/junior_school_customization/doctype/session/session.py
+++ b/nl_school/junior_school_customization/doctype/session/session.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Navari and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Session(Document):
+    pass

--- a/nl_school/junior_school_customization/doctype/session/test_session.py
+++ b/nl_school/junior_school_customization/doctype/session/test_session.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Navari and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestSession(FrappeTestCase):
+    pass


### PR DESCRIPTION
This PR introduces a new custom **Doctype named `Sessions`**, built to support the structured recording of **mental health and wellbeing sessions** conducted in schools. The Doctype is intended for use by counselors and school health professionals working with both **individual students** and **groups**.

---

#### Why This Is Needed

Mental health tracking in schools involves different data points depending on whether the session is **individual (1-on-1)** or a **group intervention**. Instead of creating separate Doctypes for each type, I’ve combined both use cases into a single flexible form to reduce duplication and simplify reporting.

---

####  Key Implementation Details

* **Session Type Field**
  A `Select` field called `session_type` determines if the session is **"Individual"** or **"Group"**.

* **Common Fields** (Always Visible)

  * `School`, `Grade`, `Stream`
  * `Year`, `Term`

* **Conditional Fields Based on Session Type**

  * **If session\_type = "Group"**

    * `Topic`, `Subtopic`, `Number of Students Trained`
    * *Only group-related fields are shown*
    
<img width="885" height="367" alt="image" src="https://github.com/user-attachments/assets/c132aaea-6a63-4370-8b82-ac8b1ddf7e2b" />

  * **If session\_type = "Individual"**

    * `Topic`, `Student ID`, `Student Name`, `Case History`, `Case Management`, `Next Steps`
    * *Fields related to individual case tracking become visible*
    
<img width="843" height="600" alt="image" src="https://github.com/user-attachments/assets/bb8e7f8b-70de-40d3-bc49-9c16c12ed7cd" />




