### PR TITLE
Feat/sessions

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -533,6 +533,7 @@
 		"misbehaviors",
 		"Shofco",
 		"Mathare",
-		"Kibera"
+		"Kibera",
+		"incase"
 	]
 }

--- a/nl_school/junior_school_customization/doctype/session/session.js
+++ b/nl_school/junior_school_customization/doctype/session/session.js
@@ -1,8 +1,29 @@
 // Copyright (c) 2025, Navari and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Session", {
-// 	refresh(frm) {
+frappe.ui.form.on("Session", {
+  topic: function (frm) {
+    frappe.call({
+      method: "nl_school.junior_school_customization.utils.get_subtopics",
+      args: {
+        topic: frm.doc.topic,
+      },
+      callback: function (response) {
+        if (response && response.message) {
+          console.log(response);
 
-// 	},
-// });
+          const subtopics = response.message.map((item) => item.topic_name);
+          console.log(subtopics);
+
+          frm.set_df_property("sub_topic", "options", subtopics.join("\n"));
+
+          if (subtopics.length > 0) {
+            frm.set_value("sub_topic", "");
+          } else {
+            frm.set_value("sub_topic", "");
+          }
+        }
+      },
+    });
+  },
+});

--- a/nl_school/junior_school_customization/doctype/session/session.js
+++ b/nl_school/junior_school_customization/doctype/session/session.js
@@ -10,10 +10,7 @@ frappe.ui.form.on("Session", {
       },
       callback: function (response) {
         if (response && response.message) {
-          console.log(response);
-
           const subtopics = response.message.map((item) => item.topic_name);
-          console.log(subtopics);
 
           frm.set_df_property("sub_topic", "options", subtopics.join("\n"));
 

--- a/nl_school/junior_school_customization/doctype/session/session.json
+++ b/nl_school/junior_school_customization/doctype/session/session.json
@@ -12,6 +12,7 @@
   "column_break_ituu",
   "year",
   "term",
+  "date",
   "cohort",
   "session_type_section",
   "type",
@@ -153,12 +154,17 @@
    "fieldtype": "Small Text",
    "label": "Case Management",
    "mandatory_depends_on": "eval:doc.type===\"Individual Session\";"
+  },
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "label": "Date"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-25 16:29:25.357635",
+ "modified": "2025-07-28 16:52:13.948376",
  "modified_by": "Administrator",
  "module": "Junior School Customization",
  "name": "Session",

--- a/nl_school/junior_school_customization/report/mental_well_being/mental_well_being.js
+++ b/nl_school/junior_school_customization/report/mental_well_being/mental_well_being.js
@@ -1,0 +1,74 @@
+// Copyright (c) 2025, Navari and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Mental Well-Being"] = {
+  filters: [
+    {
+      fieldname: "company",
+      label: __("School"),
+      fieldtype: "Link",
+      options: "Company",
+      reqd: 1,
+    },
+    {
+      fieldname: "academic_year",
+      label: __("Academic Year"),
+      fieldtype: "Link",
+      options: "Academic Year",
+      reqd: 0,
+    },
+    {
+      fieldname: "academic_term",
+      label: __("Academic Term"),
+      fieldtype: "Link",
+      options: "Academic Term",
+      reqd: 0,
+    },
+    {
+      fieldname: "program",
+      label: __("Grade"),
+      fieldtype: "Link",
+      options: "Program",
+      reqd: 0,
+      get_query: function () {
+        const company = frappe.query_report.get_filter_value("company");
+        console.log("company", company);
+
+        return {
+          filters: {
+            company: company,
+          },
+        };
+      },
+    },
+    {
+      fieldname: "student_group",
+      label: __("Stream"),
+      fieldtype: "Link",
+      options: "Student Group",
+      reqd: 0,
+      get_query: function () {
+        const company = frappe.query_report.get_filter_value("company");
+        console.log("company", company);
+
+        return {
+          filters: {
+            company: company,
+          },
+        };
+      },
+    },
+    {
+      fieldname: "date",
+      label: "Date",
+      fieldtype: "Date",
+    },
+    {
+      fieldname: "session_type",
+      label: "Session Type",
+      fieldtype: "Select",
+      options: ["Group Session", "Individual Session"],
+      reqd: 1,
+    },
+  ],
+};

--- a/nl_school/junior_school_customization/report/mental_well_being/mental_well_being.json
+++ b/nl_school/junior_school_customization/report/mental_well_being/mental_well_being.json
@@ -1,0 +1,29 @@
+{
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2025-07-28 16:10:39.509075",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letter_head": "Default",
+ "letterhead": null,
+ "modified": "2025-07-28 16:10:39.509075",
+ "modified_by": "Administrator",
+ "module": "Junior School Customization",
+ "name": "Mental Well-Being",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Session",
+ "report_name": "Mental Well-Being",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "System Manager"
+  }
+ ],
+ "timeout": 0
+}

--- a/nl_school/junior_school_customization/report/mental_well_being/mental_well_being.py
+++ b/nl_school/junior_school_customization/report/mental_well_being/mental_well_being.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2025, Navari and contributors
+# For license information, please see license.txt
+import frappe
+from frappe.query_builder import DocType
+
+
+def execute(filters=None):
+    columns, data = get_columns(filters), get_data(filters)
+    return columns, data
+
+
+def get_columns(filters):
+    session_type = filters.get("session_type") if filters else None
+
+    if session_type == "Individual Session":
+        columns = [
+            {
+                "fieldname": "cohort",
+                "label": "Cohort",
+                "fieldtype": "Data",
+                "width": 120,
+            },
+            {
+                "fieldname": "student",
+                "label": "Student",
+                "fieldtype": "Link",
+                "options": "Student",
+                "width": 120,
+            },
+            {
+                "fieldname": "student_name",
+                "label": "Student Name",
+                "fieldtype": "Data",
+                "options": "student",
+                "width": 120,
+            },
+            {"fieldname": "date", "label": "Date", "fieldtype": "Date", "width": 120},
+            {
+                "fieldname": "topic",
+                "label": "Topic",
+                "fieldtype": "Link",
+                "options": "Topic",
+                "width": 120,
+            },
+            {
+                "fieldname": "case_history",
+                "label": "Case History",
+                "fieldtype": "Text",
+                "width": 200,
+            },
+            {
+                "fieldname": "case_management",
+                "label": "Case Management",
+                "fieldtype": "Text",
+                "width": 200,
+            },
+            {
+                "fieldname": "grade",
+                "label": "Grade",
+                "fieldtype": "Link",
+                "options": "Program",
+                "width": 120,
+            },
+            {
+                "fieldname": "stream",
+                "label": "Stream",
+                "fieldtype": "Link",
+                "options": "Student Group",
+                "width": 120,
+            },
+            {
+                "fieldname": "next_steps",
+                "label": "Next Steps",
+                "fieldtype": "Text",
+                "width": 200,
+            },
+        ]
+    elif session_type == "Group Session":
+        columns = [
+            {
+                "fieldname": "cohort",
+                "label": "Cohort",
+                "fieldtype": "Data",
+                "width": 120,
+            },
+            {"fieldname": "date", "label": "Date", "fieldtype": "Date", "width": 120},
+            {
+                "fieldname": "sub_topic",
+                "label": "Sub Topic",
+                "fieldtype": "Link",
+                "options": "Topic",
+                "width": 120,
+            },
+            {
+                "fieldname": "topic",
+                "label": "Topic",
+                "fieldtype": "Link",
+                "options": "Topic",
+                "width": 120,
+            },
+            {
+                "fieldname": "grade",
+                "label": "Grade",
+                "fieldtype": "Link",
+                "options": "Program",
+                "width": 120,
+            },
+            {
+                "fieldname": "stream",
+                "label": "Stream",
+                "fieldtype": "Link",
+                "options": "Student Group",
+                "width": 120,
+            },
+            {
+                "fieldname": "number_of_students_trained",
+                "label": "Number of Students Trained",
+                "fieldtype": "Int",
+                "width": 120,
+            },
+        ]
+
+    return columns
+
+
+def get_data(filters=None):
+    Session = DocType("Session")
+
+    filters = filters or {}
+    conditions = get_conditions(filters, Session)
+    session_type = filters.get("session_type")
+
+    if not session_type:
+        return []
+
+    if session_type == "Individual Session":
+        fields = [
+            Session.cohort,
+            Session.student,
+            Session.student_name,
+            Session.date,
+            Session.topic,
+            Session.case_history,
+            Session.case_management,
+            Session.grade,
+            Session.stream,
+            Session.next_steps,
+        ]
+    elif session_type == "Group Session":
+        fields = [
+            Session.cohort,
+            Session.date,
+            Session.sub_topic,
+            Session.topic,
+            Session.grade,
+            Session.stream,
+            Session.no_students_trained.as_("number_of_students_trained"),
+        ]
+    else:
+        return []
+
+    query = frappe.qb.from_(Session).select(*fields).where(Session.type == session_type)
+
+    for condition in conditions:
+        query = query.where(condition)
+    data = query.run()
+    return data
+
+
+def get_conditions(filters, doctype):
+    conditions = []
+
+    if filters.get("company"):
+        conditions.append(doctype.school == filters.get("company"))
+
+    if filters.get("academic_year"):
+        conditions.append(doctype.year == filters.get("academic_year"))
+
+    if filters.get("academic_term"):
+        conditions.append(doctype.term == filters.get("academic_term"))
+
+    if filters.get("program"):
+        conditions.append(doctype.grade == filters.get("program"))
+
+    if filters.get("student_group"):
+        conditions.append(doctype.stream == filters.get("student_group"))
+
+    if filters.get("date"):
+        conditions.append(doctype.date == filters.get("date"))
+
+    if filters.get("session_type"):
+        conditions.append(doctype.type == filters.get("session_type"))
+
+    return conditions

--- a/nl_school/junior_school_customization/utils.py
+++ b/nl_school/junior_school_customization/utils.py
@@ -257,3 +257,10 @@ def close_assessment_plan():
 def get_education_settings():
     settings = frappe.get_single("Education Settings")
     return settings
+
+
+@frappe.whitelist()
+def get_subtopics(topic):
+    return frappe.db.get_all(
+        "Course Topic", filters={"parent": topic}, fields=["name", "topic_name"]
+    )


### PR DESCRIPTION

This PR introduces dynamic behavior in the **Session** form to populate the `sub_topic` select field based on the selected `topic`.

#### Changes Made

* Implemented a **Frappe client script** to call a backend method when the `topic` field is changed.
* Added a **whitelisted Python method** `get_subtopics()` to fetch related `Course Topic` entries.
* Updated the `sub_topic` field options dynamically with the returned `topic_name` values.

#### Purpose

This enhances usability by ensuring that only relevant subtopics are shown to the user based on their topic selection.

