### PR TITLE
Add Party Name Field to Satisfaction Document and Report

### DIFF
--- a/nl_school/junior_school_customization/doctype/satisfaction/satisfaction.js
+++ b/nl_school/junior_school_customization/doctype/satisfaction/satisfaction.js
@@ -1,8 +1,14 @@
 // Copyright (c) 2025, Navari and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Satisfaction", {
-// 	refresh(frm) {
+frappe.ui.form.on("Satisfaction", {
+  party: function (frm) {
+    const doctype = frm.doc.party_type;
 
-// 	},
-// });
+    frappe.db
+      .get_value(doctype, frm.doc.party, `${doctype.toLowerCase()}_name`)
+      .then((response) => {
+        frm.doc.party_name = `${Object.values(response.message)}`;
+      });
+  },
+});

--- a/nl_school/junior_school_customization/doctype/satisfaction/satisfaction.json
+++ b/nl_school/junior_school_customization/doctype/satisfaction/satisfaction.json
@@ -9,6 +9,7 @@
   "school",
   "party_type",
   "party",
+  "party_name",
   "column_break_uqec",
   "year",
   "grade",
@@ -88,12 +89,18 @@
    "label": "Satisfaction Scores",
    "options": "Satisfaction Scores",
    "reqd": 1
+  },
+  {
+   "fieldname": "party_name",
+   "fieldtype": "Data",
+   "label": "Party Name",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-30 18:34:18.392404",
+ "modified": "2025-07-31 15:46:50.703298",
  "modified_by": "Administrator",
  "module": "Junior School Customization",
  "name": "Satisfaction",

--- a/nl_school/junior_school_customization/report/satisfaction_report/satisfaction_report.py
+++ b/nl_school/junior_school_customization/report/satisfaction_report/satisfaction_report.py
@@ -30,6 +30,7 @@ def get_columns(filters):
             "fieldtype": "Link",
             "options": "Satisfaction",
             "width": 200,
+            "hidden": 1 if filters.get("party_type") == "Teacher" else 0,
         },
         {
             "fieldname": "party",
@@ -37,12 +38,14 @@ def get_columns(filters):
             "fieldtype": "Link",
             "options": party_type_options,
             "width": 200,
+            "hidden": 1 if filters.get("party_type") == "Teacher" else 0,
         },
         {
             "fieldname": "party_name",
             "label": "Party Name",
             "fieldtype": "Data",
             "width": 200,
+            "hidden": 1 if filters.get("party_type") == "Teacher" else 0,
         },
         {
             "fieldname": "term_1_score",

--- a/nl_school/junior_school_customization/report/satisfaction_report/satisfaction_report.py
+++ b/nl_school/junior_school_customization/report/satisfaction_report/satisfaction_report.py
@@ -7,7 +7,6 @@ from frappe.query_builder import DocType
 
 def execute(filters=None):
     columns, data = get_columns(filters), get_data(filters)
-    print("data", data)
     return columns, data
 
 
@@ -37,6 +36,12 @@ def get_columns(filters):
             "label": "Party",
             "fieldtype": "Link",
             "options": party_type_options,
+            "width": 200,
+        },
+        {
+            "fieldname": "party_name",
+            "label": "Party Name",
+            "fieldtype": "Data",
             "width": 200,
         },
         {
@@ -87,7 +92,9 @@ def get_data(filters):
         if not parent_names_to_fetch:
             return []
 
-    base_query = frappe.qb.from_(SD).select(SD.name, SD.party, SD.avg_score)
+    base_query = frappe.qb.from_(SD).select(
+        SD.name, SD.party, SD.party_name, SD.avg_score
+    )
 
     parent_conditions = []
     if filters.get("company"):
@@ -137,6 +144,7 @@ def get_data(filters):
         row = {
             "name": record.name,
             "party": record.party,
+            "party_name": record.party_name,
             "term_1_score": term_scores["term_1_score"],
             "term_2_score": term_scores["term_2_score"],
             "term_3_score": term_scores["term_3_score"],


### PR DESCRIPTION

This pull request adds a new `party_name` field to the Satisfaction DocType and updates the corresponding report to display this field. The changes aim to improve the clarity and usability of the Satisfaction document and its reporting.

**Key Changes:**

* **New `party_name` Field:** A new `party_name` field has been added to the `Satisfaction` DocType to store the name of the linked party.
* **Client-side Logic:** A client script has been implemented to automatically populate the `party_name` field when a value is selected in the `party` dynamic link field.
* **Report Updates:**
    * The Satisfaction report now includes a new `Party Name` column to display the fetched name.
   
<img width="902" height="254" alt="image" src="https://github.com/user-attachments/assets/eab26e6a-8f8d-493f-ad00-18200927d3fa" />

    * Conditional logic has been added to the report's `get_columns` function to hide the "SAT Name", "Party", and "Party Name" columns when the "Party Type" filter is set to "Teacher".
    * 
<img width="520" height="208" alt="image" src="https://github.com/user-attachments/assets/55d18b82-9adf-48ed-992c-49fd98684159" />

* **Data Retrieval:** The report's `get_data` function has been updated to include the `party_name` field in the database query.
