### PR TITLE
Parent Engagement DocType and Logic

### DIFF
--- a/nl_school/junior_school_customization/doctype/parental_engagement/parental_engagement.js
+++ b/nl_school/junior_school_customization/doctype/parental_engagement/parental_engagement.js
@@ -1,8 +1,16 @@
 // Copyright (c) 2025, Navari and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Parental Engagement", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Parental Engagement", {
+  student: (frm) => {
+    frappe.call({
+      method:
+        "nl_school.junior_school_customization.utils.get_student_guardian",
+      args: { student: frm.doc.student },
+      callback: (r) => {
+        frm.doc.parent1 = r.message;
+        refresh_field("parent1");
+      },
+    });
+  },
+});

--- a/nl_school/junior_school_customization/doctype/parental_engagement/parental_engagement.js
+++ b/nl_school/junior_school_customization/doctype/parental_engagement/parental_engagement.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Navari and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Parental Engagement", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/nl_school/junior_school_customization/doctype/parental_engagement/parental_engagement.json
+++ b/nl_school/junior_school_customization/doctype/parental_engagement/parental_engagement.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:{student_name}-{YYYY}",
  "creation": "2025-08-04 07:45:12.732257",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -8,6 +9,8 @@
   "student",
   "student_name",
   "parent1",
+  "column_break_moed",
+  "year",
   "engagement_type_section",
   "discussed_school_topics",
   "helped_with_homework",
@@ -19,13 +22,15 @@
   {
    "fieldname": "student",
    "fieldtype": "Link",
+   "in_global_search": 1,
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Student",
    "options": "Student",
    "reqd": 1
   },
   {
-   "fetch_from": "student.custom_student_id_name",
+   "fetch_from": "student.student_name",
    "fieldname": "student_name",
    "fieldtype": "Data",
    "label": "Student Name",
@@ -71,15 +76,27 @@
    "label": "Frequency",
    "options": "\nDaily\nWeekly\nMonthly\nRarely",
    "reqd": 1
+  },
+  {
+   "fieldname": "column_break_moed",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "year",
+   "fieldtype": "Link",
+   "label": "Year",
+   "options": "Academic Year",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-04 08:10:36.023776",
+ "modified": "2025-08-04 08:51:26.575107",
  "modified_by": "Administrator",
  "module": "Junior School Customization",
  "name": "Parental Engagement",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {

--- a/nl_school/junior_school_customization/doctype/parental_engagement/parental_engagement.json
+++ b/nl_school/junior_school_customization/doctype/parental_engagement/parental_engagement.json
@@ -1,0 +1,102 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-08-04 07:45:12.732257",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "student",
+  "student_name",
+  "parent1",
+  "engagement_type_section",
+  "discussed_school_topics",
+  "helped_with_homework",
+  "encouraged_education",
+  "column_break_xcsh",
+  "frequency"
+ ],
+ "fields": [
+  {
+   "fieldname": "student",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Student",
+   "options": "Student",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "student.custom_student_id_name",
+   "fieldname": "student_name",
+   "fieldtype": "Data",
+   "label": "Student Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "parent1",
+   "fieldtype": "Link",
+   "label": "Parent",
+   "options": "Guardian",
+   "read_only": 1
+  },
+  {
+   "fieldname": "engagement_type_section",
+   "fieldtype": "Section Break",
+   "label": "Engagement Type"
+  },
+  {
+   "default": "0",
+   "fieldname": "discussed_school_topics",
+   "fieldtype": "Check",
+   "label": "Discussed School Topics"
+  },
+  {
+   "default": "0",
+   "fieldname": "helped_with_homework",
+   "fieldtype": "Check",
+   "label": "Helped with Homework"
+  },
+  {
+   "default": "0",
+   "fieldname": "encouraged_education",
+   "fieldtype": "Check",
+   "label": "Encouraged Education"
+  },
+  {
+   "fieldname": "column_break_xcsh",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "frequency",
+   "fieldtype": "Select",
+   "label": "Frequency",
+   "options": "\nDaily\nWeekly\nMonthly\nRarely",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-08-04 08:10:36.023776",
+ "modified_by": "Administrator",
+ "module": "Junior School Customization",
+ "name": "Parental Engagement",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/nl_school/junior_school_customization/doctype/parental_engagement/parental_engagement.json
+++ b/nl_school/junior_school_customization/doctype/parental_engagement/parental_engagement.json
@@ -9,6 +9,7 @@
   "student",
   "student_name",
   "parent1",
+  "parent_name",
   "column_break_moed",
   "year",
   "engagement_type_section",
@@ -87,12 +88,19 @@
    "label": "Year",
    "options": "Academic Year",
    "reqd": 1
+  },
+  {
+   "fetch_from": "parent1.guardian_name",
+   "fieldname": "parent_name",
+   "fieldtype": "Data",
+   "label": "Parent Name",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-04 08:51:26.575107",
+ "modified": "2025-08-04 09:28:10.838240",
  "modified_by": "Administrator",
  "module": "Junior School Customization",
  "name": "Parental Engagement",

--- a/nl_school/junior_school_customization/doctype/parental_engagement/parental_engagement.py
+++ b/nl_school/junior_school_customization/doctype/parental_engagement/parental_engagement.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Navari and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class ParentalEngagement(Document):
+    pass

--- a/nl_school/junior_school_customization/doctype/parental_engagement/test_parental_engagement.py
+++ b/nl_school/junior_school_customization/doctype/parental_engagement/test_parental_engagement.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Navari and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestParentalEngagement(FrappeTestCase):
+    pass

--- a/nl_school/junior_school_customization/utils.py
+++ b/nl_school/junior_school_customization/utils.py
@@ -264,3 +264,8 @@ def get_subtopics(topic):
     return frappe.db.get_all(
         "Course Topic", filters={"parent": topic}, fields=["name", "topic_name"]
     )
+
+
+@frappe.whitelist()
+def get_student_guardian(student):
+    return frappe.db.get_value("Student Guardian", {"parent": student}, "guardian")


### PR DESCRIPTION
This pull request introduces a new **Parental Engagement** DocType and associated logic to track how parents or guardians engage with a student's education. Data associated with this doctype will be collected annually

#### Key Features and Changes:
- **New DocType:** A new `Parental Engagement` DocType has been created to record specific instances of parent/guardian interaction.
- **Fields:** The DocType includes fields to link a `Student` and their `Guardian`, as well as a selection of fields to describe the type of engagement, such as:
    - `discussed_school_topics` (Check)
    - `helped_with_homework` (Check)
    - `encouraged_education` (Check)
    - `frequency` (Select: Daily, Weekly, Monthly, Rarely)
- **Automatic Naming:** Document names will be automatically generated using the format `[student_name]-[year]`.
- **Field Linkage:** A custom client-side script has been added to automatically fetch and populate the `parent1` field when a `student` is selected, linking the engagement record to the student's designated guardian.
- **Backend Whitelist Method:** A new backend method `get_student_guardian` was created to safely retrieve the guardian's name associated with a student, which is then used by the client-side script.

This new DocType will help in better understanding and tracking the level of parental involvement in a student's academic life.