### PR TITLE
Parental Engagement Report

### DIFF
--- a/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.js
+++ b/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.js
@@ -2,5 +2,31 @@
 // For license information, please see license.txt
 
 frappe.query_reports["Parental Engagement"] = {
-  filters: [],
+  filters: [
+    {
+      fieldname: "company",
+      label: __("School"),
+      fieldtype: "Link",
+      options: "Company",
+      reqd: 0,
+    },
+    {
+      fieldname: "year",
+      label: "Academic Year",
+      fieldtype: "Link",
+      options: "Academic Year",
+      reqd: 0,
+    },
+    {
+      fieldname: "engagement_type",
+      label: __("Engagement Type"),
+      fieldtype: "Select",
+      options: [
+        "Discussed School Topics",
+        "Helped with Homework",
+        "Encouraged Education",
+      ],
+      reqd: 0,
+    },
+  ],
 };

--- a/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.js
+++ b/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.js
@@ -18,6 +18,13 @@ frappe.query_reports["Parental Engagement"] = {
       reqd: 1,
     },
     {
+      fieldname: "stream",
+      label: "Stream",
+      fieldtype: "Link",
+      options: "Student Group",
+      reqd: 0,
+    },
+    {
       fieldname: "engagement_type",
       label: __("Engagement Type"),
       fieldtype: "Select",

--- a/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.js
+++ b/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.js
@@ -8,20 +8,21 @@ frappe.query_reports["Parental Engagement"] = {
       label: __("School"),
       fieldtype: "Link",
       options: "Company",
-      reqd: 0,
+      reqd: 1,
     },
     {
       fieldname: "year",
       label: "Academic Year",
       fieldtype: "Link",
       options: "Academic Year",
-      reqd: 0,
+      reqd: 1,
     },
     {
       fieldname: "engagement_type",
       label: __("Engagement Type"),
       fieldtype: "Select",
       options: [
+        "",
         "Discussed School Topics",
         "Helped with Homework",
         "Encouraged Education",

--- a/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.js
+++ b/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.js
@@ -29,4 +29,22 @@ frappe.query_reports["Parental Engagement"] = {
       reqd: 0,
     },
   ],
+
+  formatter: function (value, row, column, data, default_formatter) {
+    const engagement_fields = [
+      "discussed_school_topics",
+      "helped_with_homework",
+      "encouraged_education",
+    ];
+
+    if (engagement_fields.includes(column.fieldname)) {
+      if (value && value !== "No") {
+        return `<span style="color: green; font-weight: bold;"> Engaged </span>`;
+      } else {
+        return `<span style="color: red; font-weight: bold;"> - </span>`;
+      }
+    }
+
+    return default_formatter(value, row, column, data);
+  },
 };

--- a/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.js
+++ b/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.js
@@ -1,0 +1,6 @@
+// Copyright (c) 2025, Navari and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Parental Engagement"] = {
+  filters: [],
+};

--- a/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.json
+++ b/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.json
@@ -1,0 +1,29 @@
+{
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2025-08-04 16:43:14.927951",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letter_head": "Default",
+ "letterhead": null,
+ "modified": "2025-08-04 16:43:14.927951",
+ "modified_by": "Administrator",
+ "module": "Junior School Customization",
+ "name": "Parental Engagement",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Parental Engagement",
+ "report_name": "Parental Engagement",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "System Manager"
+  }
+ ],
+ "timeout": 0
+}

--- a/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.py
+++ b/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2025, Navari and contributors
+# For license information, please see license.txt
+
+# import frappe
+
+
+def execute(filters=None):
+    columns, data = get_columns(), get_data(filters)
+    return columns, data
+
+
+def get_columns():
+    columns = [
+        {
+            "fieldname": "student",
+            "label": "Student",
+            "fieldtype": "Link",
+            "options": "Student",
+            "width": 200,
+        },
+        {
+            "fieldname": "student",
+            "label": "Student Name",
+            "fieldtype": "Data",
+            "width": 200,
+        },
+        {
+            "fieldname": "parent",
+            "label": "Parent",
+            "fieldtype": "Link",
+            "options": "Guardian",
+            "width": 200,
+        },
+        {
+            "fieldname": "parent",
+            "label": "Parent Name",
+            "fieldtype": "Data",
+            "width": 200,
+        },
+        {
+            "fieldname": "discussed_topics",
+            "label": "Discussed School Topics",
+            "fieldtype": "Data",
+        },
+        {
+            "fieldname": "helped_homework",
+            "label": "Helped with Homework",
+            "fieldtype": "Data",
+        },
+        {
+            "fieldname": "encouraged_education",
+            "label": "Encouraged Education",
+            "fieldtype": "Data",
+        },
+        {
+            "fieldname": "frequency",
+            "label": "Engagement Frequency",
+            "fieldtype": "Data",
+            "width": 200,
+        },
+    ]
+    return columns
+
+
+def get_data(filters):
+    return []

--- a/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.py
+++ b/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.py
@@ -98,6 +98,5 @@ def get_data(filters):
 
     for condition in conditions:
         query = query.where(condition)
-    print(query.run())
 
     return query.run()

--- a/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.py
+++ b/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2025, Navari and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe.query_builder import DocType
 
 
 def execute(filters=None):
@@ -19,13 +20,13 @@ def get_columns():
             "width": 200,
         },
         {
-            "fieldname": "student",
+            "fieldname": "student_name",
             "label": "Student Name",
             "fieldtype": "Data",
             "width": 200,
         },
         {
-            "fieldname": "parent",
+            "fieldname": "parent1",
             "label": "Parent",
             "fieldtype": "Link",
             "options": "Guardian",
@@ -38,12 +39,12 @@ def get_columns():
             "width": 200,
         },
         {
-            "fieldname": "discussed_topics",
+            "fieldname": "discussed_school_topics",
             "label": "Discussed School Topics",
             "fieldtype": "Data",
         },
         {
-            "fieldname": "helped_homework",
+            "fieldname": "helped_with_homework",
             "label": "Helped with Homework",
             "fieldtype": "Data",
         },
@@ -62,5 +63,41 @@ def get_columns():
     return columns
 
 
+def map_types(filters=None):
+    if filters:
+        if filters.get("engagement_type"):
+            stripped = filters.get("engagement_type")
+            stripped.lower().replace(" ", "_")
+
+            return stripped
+
+
 def get_data(filters):
-    return []
+    PE = DocType("Parental Engagement")
+
+    query = frappe.qb.from_(PE).select(
+        PE.student,
+        PE.student_name,
+        PE.parent1,
+        PE.parent_name,
+        PE.discussed_school_topics,
+        PE.helped_with_homework,
+        PE.encouraged_education,
+        PE.frequency,
+    )
+
+    conditions = []
+    if filters.get("company"):
+        conditions.append(PE.year == filters.get("company"))
+    if filters.get("year"):
+        conditions.append(PE.year == filters.get("year"))
+    if filters.get("Engagement Type"):
+        field_name = map_types(filters)
+        if field_name:
+            conditions.append(getattr(PE, field_name) == 1)
+
+    for condition in conditions:
+        query = query.where(condition)
+    print(query.run())
+
+    return query.run()

--- a/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.py
+++ b/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.py
@@ -17,26 +17,26 @@ def get_columns():
             "label": "Student",
             "fieldtype": "Link",
             "options": "Student",
-            "width": 200,
+            "width": 150,
         },
         {
             "fieldname": "student_name",
             "label": "Student Name",
             "fieldtype": "Data",
-            "width": 200,
+            "width": 150,
         },
         {
             "fieldname": "parent1",
             "label": "Parent",
             "fieldtype": "Link",
             "options": "Guardian",
-            "width": 200,
+            "width": 150,
         },
         {
             "fieldname": "parent",
             "label": "Parent Name",
             "fieldtype": "Data",
-            "width": 200,
+            "width": 150,
         },
         {
             "fieldname": "discussed_school_topics",
@@ -70,6 +70,16 @@ def map_types(type):
 def get_data(filters):
     PE = DocType("Parental Engagement")
 
+    students = []
+    if filters.get("stream"):
+        stream = filters.get("stream")
+        students = frappe.get_all(
+            "Student Group Student", filters={"parent": stream}, fields=["student"]
+        )
+        students = [student.student for student in students]
+        if not students:
+            return []
+
     query = frappe.qb.from_(PE).select(
         PE.student,
         PE.student_name,
@@ -93,5 +103,8 @@ def get_data(filters):
 
     for condition in conditions:
         query = query.where(condition)
+
+    if students:
+        query = query.where(PE.student.isin(students))
 
     return query.run()

--- a/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.py
+++ b/nl_school/junior_school_customization/report/parental_engagement/parental_engagement.py
@@ -63,13 +63,8 @@ def get_columns():
     return columns
 
 
-def map_types(filters=None):
-    if filters:
-        if filters.get("engagement_type"):
-            stripped = filters.get("engagement_type")
-            stripped.lower().replace(" ", "_")
-
-            return stripped
+def map_types(type):
+    return type.lower().replace(" ", "_")
 
 
 def get_data(filters):
@@ -88,11 +83,11 @@ def get_data(filters):
 
     conditions = []
     if filters.get("company"):
-        conditions.append(PE.year == filters.get("company"))
+        conditions.append(PE.school == filters.get("company"))
     if filters.get("year"):
         conditions.append(PE.year == filters.get("year"))
-    if filters.get("Engagement Type"):
-        field_name = map_types(filters)
+    if filters.get("engagement_type"):
+        field_name = map_types(filters.get("engagement_type"))
         if field_name:
             conditions.append(getattr(PE, field_name) == 1)
 


### PR DESCRIPTION
This PR introduces a new report named "Parental Engagement" to help schools and administrators track and analyze parental involvement. The report provides a clear view of how guardians are participating in their child's education based on data from the Parental Engagement doctype.

### **What it Does**

This report collects and organizes information about parent-student interactions. It displays a list of students, their parents, and shows whether the parents have:
* **Discussed School Topics** with their child.
* **Helped with Homework**.
* **Encouraged Education** in general.

For each of these activities, the report provides a simple, easy-to-read indicator: "Engaged" in green if the parent is involved, or a dash in red if they are not. It also tells you how frequently this engagement is happening.



* **Filter by Engagement Type:** This is a powerful feature. You can choose to see *only* the parents who have helped with homework, or *only* those who have discussed school topics. This helps you focus on specific areas of involvement.

<img width="887" height="254" alt="image" src="https://github.com/user-attachments/assets/1243cb85-382d-4779-b855-3e346c9882db" />
