### PR TITLE
Feat/enhance timetable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@ Junior School is a custom [Frappe](https://frappe.io/framework) application that
 ## Table of Contents
 
 - [📚 Frappe Education Extension Customization](#-frappe-education-extension-customization)
-- [🚀 Project Overview](#-project-overview)  
+- [🚀 Project Overview](#-project-overview)
 - [Key Features](#key-features)
-  - [1. 🗓️ School Timetable Page](#1-️-school-timetable-page)
-  - [2. ⚙️ Auto-Generation of Timetable](#2-️-auto-generation-of-timetable)
-  - [3. 🧑🏽‍🎓 Enhanced Student Attendance](#3--enhanced-student-attendance)
-  - [4. 🗂️ Subject Scheduling Tool](#4-️-subject-scheduling-tool)
-  - [5. 🧾 Student Report Generation Tool](#5--student-report-generation-tool)
-  - [6. 👨🏽‍💻 Student ID-Based Email and User Auto-Creation](#6--student-id-based-email-and-user-auto-creation)
-  - [7. 🏫 School as Company](#7--school-as-company)
-  - [8. 📊 Assessment Plan Status](#8--assessment-plan-status)
-  - [9. 🎓 Academic Year Setup & Automated Student Promotion System](#9--academic-year-setup--automated-student-promotion-system)
-  - [10. 🚪 Student Auto-Deactivation](#10--student-auto-deactivation)
-  - [11. 📅 Academic Term Update](#11--academic-term-update)
+    - [1. 🗓️ School Timetable Page](#1-️-school-timetable-page)
+    - [2. ⚙️ Auto-Generation of Timetable](#2-️-auto-generation-of-timetable)
+    - [3. 🧑🏽‍🎓 Enhanced Student Attendance](#3--enhanced-student-attendance)
+    - [4. 🗂️ Subject Scheduling Tool](#4-️-subject-scheduling-tool)
+    - [5. 🧾 Student Report Generation Tool](#5--student-report-generation-tool)
+    - [6. 👨🏽‍💻 Student ID-Based Email and User Auto-Creation](#6--student-id-based-email-and-user-auto-creation)
+    - [7. 🏫 School as Company](#7--school-as-company)
+    - [8. 📊 Assessment Plan Status](#8--assessment-plan-status)
+    - [9. 🎓 Academic Year Setup & Automated Student Promotion System](#9--academic-year-setup--automated-student-promotion-system)
+    - [10. 🚪 Student Auto-Deactivation](#10--student-auto-deactivation)
+    - [11. 📅 Academic Term Update](#11--academic-term-update)
 - [🛠️ Installation](#️-installation)
-  - [✅ Dependencies](#-dependencies)
-  - [☁️ Managed Hosting Frappe Cloud](#️-managed-hosting-frappe-cloud)
-  - [🧑🏿‍💻 Self Hosting](#-self-hosting)
+    - [✅ Dependencies](#-dependencies)
+    - [☁️ Managed Hosting Frappe Cloud](#️-managed-hosting-frappe-cloud)
+    - [🧑🏿‍💻 Self Hosting](#-self-hosting)
 - [Key DocTypes](#key-doctypes)
 - [Reports](#reports)
 - [Dashboards](#dashboards)
@@ -35,6 +35,7 @@ Junior School is a custom [Frappe](https://frappe.io/framework) application that
 This extension was built to address the unique needs of junior school management, providing sophisticated tools for educational institutions that require multi-campus support, flexible scheduling, and automated administrative processes. The system maintains compatibility with standard [Frappe Education](https://frappe.io/education) while adding specialized functionality for enhanced school operations.
 
 ---
+
 ## 🔄 System Workflows
 
 ### Core Process Flows
@@ -48,136 +49,174 @@ graph TD
     E --> F[Report Generation]
     F --> G[Year-End Promotion]
     G --> H[Auto-Deactivation if Leaving]
-    
+
     I[Timetable Setup] --> J[Define Subjects/Rules]
     J --> K[Assign Teachers/Rooms]
     K --> L[Generate Timetable]
     L --> M[Calendar View/Edits]
-    
+
     N[Academic Year] --> O[Auto-Create Year]
     O --> P[Update Terms]
     P --> Q[Close Assessments]
 ```
----
 
+---
 
 ## Key Features
 
 ### 1. 🗓️ School Timetable Page
 
-A new **School Timetable View** has been implemented using a calendar interface. Type `Timetable` in search bar and click on first suggestion `Open Timetable`.
+The School Timetable View is a read-only interactive calendar. Open it by typing `Timetable` in the search bar and click on first suggestion `Open Timetable`.
 
-![Screenshot 2025-04-14 at 16 59 16](https://github.com/user-attachments/assets/f749a945-0457-4116-bb91-0cc266148b78)
+#### Calendar
 
-The key features include:
+- Built on **FullCalendar 6** — `timeGridWeek` (default), `timeGridDay`, and `list/agenda` views.
+- Clicking any event shows a read-only popup with: course, date, time, class, teacher, and room.
 
--   **Calendar Display**: Weekly timetable view (Sun–Sat) showing subjects, teachers, and streams.
-    
--   **Filtering Options**:
-    
-    -   **Levels**: e.g., Pre-primary, Primary
-        
-    -   **Teachers**: Filter to view specific teacher schedules
-        
-        ![Screenshot 2025-04-14 at 17 03 03](https://github.com/user-attachments/assets/1449cf44-3351-4e17-a3a5-43657a2cac28)
-    -   **Streams**: Allows filtering based on class streams
-        
--   **Print Functionality**: Filter as required and print the timetable (e.g., per teacher or per stream).
-    
--   **Assumption**: The timetable repeats weekly, so only a one-week view is necessary.
-    ---
+#### Filters
 
-**Interactive Editing**:
+| Filter             | Behaviour                                                                |
+| ------------------ | ------------------------------------------------------------------------ |
+| **Academic Term**  | Jumps the calendar to the term's start date and narrows the data fetch   |
+| **Class (Stream)** | Narrows to that class's lessons; can be combined with the Teacher filter |
+| **Teacher**        | Narrows to that teacher's lessons; can be combined with the Class filter |
+| **Clear**          | Resets all filters                                                       |
 
--   Users can click any scheduled session to view details in a modal pop-up.
-    
--   The modal allows editing and submitting updates, which reflect on the backend immediately.
-    
-![Screenshot 2025-04-15 at 17 28 08](https://github.com/user-attachments/assets/a3135465-3e6c-4d56-ab64-a8bd81847b9f)
+All three filters are independent and can be active at the same time. For example, selecting both a stream and a teacher shows only that teacher's lessons within that specific class — useful for checking a teacher's workload in a particular grade.
 
-* The user can also click in a space and schedule a class.
+#### Print
+
+The **Print** button generates a printable A4 landscape table for exactly what is currently displayed:
+
+- **Week view** → Mon–Fri table with actual dates in each row header.
+- **Day view** → single-day table.
+- Each time-slot cell can contain multiple classes (parallel sessions are stacked and separated by a dashed line).
+
+> The print range is derived from `calendar.view.currentStart` / `currentEnd`
 
 ---
 
 ### 2. ⚙️ Auto-Generation of Timetable
 
-To streamline scheduling, an automated timetable generator has been introduced using a **Single Doctype**: `Timetable Generator`.
+The timetable generator is a **Single Doctype** (`Timetable Generator`) that schedules a full academic term automatically.
 
 ![Screenshot 2025-04-14 at 17 05 50](https://github.com/user-attachments/assets/3f8c5b49-30dd-4ae9-a449-827b3003e6cc)
 
-#### Structure:
+#### Configuration tabs
 
--   **Main Fields**:
-    
-    -   `Academic Year`
-    -   `Academic Term`
-    -  `Default Time Slots`
-    -  `Lesson Starts`
-    -  `Lesson Ends`
-        
-#### Child Tables:
+**Details** — Academic Year, Academic Term (the term whose Student Groups will be scheduled), School, default lesson hours, and default period duration.
 
-**a) Subject Rules**  
-Defines subject-level constraints:
+**Subject** — one row per subject with frequency per week, allow double lessons, and max double lessons per week.
 
--   Subject
-    
--   Max Time per Session
-    
--   Frequency Per Week
-    
--   Allow Double Lessons?
-    
--   Max Double Lessons Per Week
-    
+**Slot & Breaks**
 
-**b) Slot & Breaks Tab**
+- **Time Slots**: periods with start time and duration. `end_time` is read-only and calculated automatically (`start_time + duration`). New rows default the duration to the document's _Default Time Slot_ value.
+- **Breaks**: select from the `Break` master. `start_time`, `end_time`, and `duration` are all read-only and auto-populated from the selected break record.
 
--   **Time Slots Table**: Define periods (e.g., period 1, 2...) with start/end times and durations.
-    
--   **Breaks Table**: Define breaks like breakfast, lunch, etc.. The user must have created this in the `Breaks` doctypes, because it auto-populates the start and end time from the chosen break.
- 
 ![Screenshot 2025-05-28 at 21 25 14](https://github.com/user-attachments/assets/b43bbfb4-e528-4b99-a799-56d7088e7245)
-   
 
-**c) Teachers Tab**  
-Contains a child table `Teacher Preference` with:
+**Teachers** — one row per teacher–subject–stream combination with max periods per day/week and optional preferred days.
 
--   Teacher Name
-    
--   Assigned Subjects and Streams
-    
--   Max Periods per Day/Week
-    
-This helps define teaching limits and areas of specialization.
+**Teaching Rooms** — assign a room to each subject–stream combination.
 
-**d) Teaching Rooms**  
-In the `Teaching Rooms` child table:
+#### Smart link filters
 
--   Assign specific rooms to each subject-stream combination.
-    
--   Junior school rooms default to classes, with extras like labs or libraries.
-    
+To reduce configuration errors, all link dropdowns are pre-filtered:
 
-#### Generation Flow:
+| Dropdown                 | Filtered to                                                                      |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| Teachers → Subject       | Subjects already in the Subject Rules tab                                        |
+| Teachers → Stream        | Student Groups belonging to the selected Academic Term                           |
+| Teaching Rooms → Subject | Subjects already in the Subject Rules tab                                        |
+| Teaching Rooms → Stream  | Streams already configured in the Teachers tab AND in the selected Academic Term |
 
-1.  User fills in all the above data and `save`.
-    
-2.  Clicks `Generate Timetable`.
-    
-3.  The process is queued for backend scheduling due to time complexity.
-    
-4.  The system manages duplicate and failed schedules with internal retry/rescheduling mechanisms.
-    
+#### Backend validation on save
 
-**🛠️ Status**:
+The document validates on every save and blocks saving with a clear error if any of these fail:
 
--   Work in progress.
-    
--   Some logic misbehaviors.
-    
--   Double lessons are yet to be fully implemented.
-  ---
+1. **Duplicate subjects** — each subject may appear only once in Subject Rules.
+2. **Teacher subject consistency** — every subject in the Teachers tab must exist in Subject Rules.
+3. **Room subject/stream consistency** — subjects and streams in Teaching Rooms must already be in Subject Rules and Teachers respectively.
+4. **Academic Term stream validation** — every stream must be a Student Group linked to the selected Academic Term. A stream from a different term would be silently skipped during generation; this check surfaces that error at save time.
+5. **Time slot alignment** — the first slot must start exactly at _Lesson Starts_; the last slot must end exactly at _Lesson Ends_; no slot may overlap any configured break.
+
+#### Scheduling algorithm
+
+Generates a base weekly template then replicates it across every week in the term. Subjects are spread evenly across Mon–Fri based on frequency (e.g. 3×/week → Mon/Wed/Fri) rather than front-loaded onto Monday.
+
+| Pass         | Room                    | Preferred days | Workload       |
+| ------------ | ----------------------- | -------------- | -------------- |
+| 1            | Subject+stream specific | Respected      | Daily + weekly |
+| 2            | Any available           | Ignored        | Daily + weekly |
+| 3 (fallback) | Force-assign            | Ignored        | Daily only     |
+
+Each run produces a different valid timetable through shuffled teacher order, randomized target-day rotation, and random ordering within same-priority subjects.
+
+#### Scoped generation
+
+Clicking **Generate Timetable** opens a dialog that groups streams by grade. The user selects which classes to (re-)generate; all other grades are left untouched.
+
+- Clearing is scoped: only the selected streams' existing schedules are deleted before new ones are created.
+- This allows generating Grade 6 first, then Grade 7, each run building on the previous without overwriting other classes.
+
+> At least one stream must be selected; clicking Generate with nothing checked shows a warning and keeps the dialog open.
+
+#### Cross-stream conflict prevention
+
+Before scheduling begins, existing Course Schedule records and Assessment Plan supervisor assignments for other streams are loaded into the scheduling engine's lookup table. This prevents the algorithm from assigning a teacher or room that is already occupied by another grade's confirmed schedule.
+
+#### Debug Info
+
+Before running generation, click **Debug Info** to verify the configuration without creating any records. It returns a read-only summary including:
+
+- Term date range and total school weeks
+- Period slots per day and lesson limits
+- Teacher, subject, classroom, and student group counts
+- Items to schedule per week and across the full term
+- Per-subject frequencies and per-stream subject assignments
+
+Use this to confirm everything is wired up correctly (right term, right streams, right subjects) before committing to a full generation run.
+
+#### Error handling
+
+- Every failed save is logged to **Frappe Error Log** with course, student group, instructor, date, time, room, and full Python traceback.
+- **Assessment Plan conflicts** (teacher is a supervisor at that time) are detected, counted separately, and logged with guidance — they do not count as hard failures.
+- A consolidated summary log groups all unique errors by frequency for quick pattern identification.
+
+#### Timetable Generation Result
+
+After generation, a `Timetable Generation Result` document is created with:
+
+- **Status**: `Complete` (zero failures, zero unscheduled), `Partial` (some issues), or `Failed`.
+- Scheduled count, unscheduled count, saved count, failed count.
+- Detailed JSON notes covering unscheduled items, diagnosis, save errors, and overlap skips.
+
+**View Timetable** — opens a full-width interactive grid with four view modes:
+
+| Mode         | Shows                         | Colour by     |
+| ------------ | ----------------------------- | ------------- |
+| Whole School | All streams simultaneously    | Subject       |
+| By Class     | One student group's full week | Subject       |
+| By Teacher   | All classes a teacher takes   | Student group |
+| By Subject   | All streams doing a subject   | Student group |
+
+The filter updates the grid client-side with no extra API calls.
+
+Two print formats are available:
+
+- **Color Print** — full-colour A4 landscape with a legend.
+- **Standard Print** — clean black-and-white layout with abbreviated subject names, period numbers, and two-letter day abbreviations (classic school timetable style).
+
+**Diagnose Unscheduled** — when any items could not be placed, a Diagnose button appears on the result. It explains for each subject–stream group exactly why it failed:
+
+1. No teacher assigned to this subject for this stream.
+2. Teacher hit their weekly/daily period cap.
+3. No room configured for this subject.
+4. Resource contention — teacher, room, and stream were simultaneously occupied in every remaining period.
+
+Each entry includes a suggested fix and a teacher workload table with colour-coded status badges.
+
+---
 
 ### 3. 🧑🏽‍🎓 Enhanced Student Attendance
 
@@ -316,7 +355,7 @@ To support **multi-school** or **multi-campus** setups within one ERPNext instan
     
 -   Allows clear scoping for:
     
-    -   Financials
+    -   Financial
         
     -   Student data
         
@@ -689,7 +728,7 @@ Use this report to:
 - 
 ### 7. Academic Performance Summary Report
 ![perf ](https://github.com/user-attachments/assets/ff2771b5-bd59-4be3-89eb-2bec520103e3)
-![perfomance summary](https://github.com/user-attachments/assets/833b1ade-9aee-41b6-81af-d118819de611)
+![performance summary](https://github.com/user-attachments/assets/833b1ade-9aee-41b6-81af-d118819de611)
 
 The **Academic Performance Summary Report** provides schools with a comprehensive overview of student academic performance across a selected academic term. It aggregates total and average scores, assigns letter grades based on a defined grading scale, and includes a visual breakdown of grade distribution for quick insights.
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ The **Print** button generates a printable A4 landscape table for exactly what i
 - **Day view** → single-day table.
 - Each time-slot cell can contain multiple classes (parallel sessions are stacked and separated by a dashed line).
 
+<img width="1308" height="776" alt="OpenTimetable" src="https://github.com/user-attachments/assets/49150bb9-3aba-45cf-9753-eb7aaca3acb7" />
+
+
 > The print range is derived from `calendar.view.currentStart` / `currentEnd`
 
 ---
@@ -100,13 +103,15 @@ The **Print** button generates a printable A4 landscape table for exactly what i
 
 The timetable generator is a **Single Doctype** (`Timetable Generator`) that schedules a full academic term automatically.
 
-![Screenshot 2025-04-14 at 17 05 50](https://github.com/user-attachments/assets/3f8c5b49-30dd-4ae9-a449-827b3003e6cc)
+<img width="1092" height="543" alt="TimeTable Generator" src="https://github.com/user-attachments/assets/6f3a359b-2ba3-44b3-b330-1b7c7d37b232" />
 
 #### Configuration tabs
 
 **Details** — Academic Year, Academic Term (the term whose Student Groups will be scheduled), School, default lesson hours, and default period duration.
 
 **Subject** — one row per subject with frequency per week, allow double lessons, and max double lessons per week.
+
+
 
 **Slot & Breaks**
 
@@ -159,6 +164,8 @@ Clicking **Generate Timetable** opens a dialog that groups streams by grade. The
 - Clearing is scoped: only the selected streams' existing schedules are deleted before new ones are created.
 - This allows generating Grade 6 first, then Grade 7, each run building on the previous without overwriting other classes.
 
+<img width="856" height="479" alt="ScopedGeneration" src="https://github.com/user-attachments/assets/3e6d6415-f3ff-40b6-b3ce-f615650f3ec5" />
+
 > At least one stream must be selected; clicking Generate with nothing checked shows a warning and keeps the dialog open.
 
 #### Cross-stream conflict prevention
@@ -174,6 +181,8 @@ Before running generation, click **Debug Info** to verify the configuration with
 - Teacher, subject, classroom, and student group counts
 - Items to schedule per week and across the full term
 - Per-subject frequencies and per-stream subject assignments
+
+<img width="625" height="797" alt="DebugInfo" src="https://github.com/user-attachments/assets/c2a3bf31-7331-490c-b35f-5b81df469b2b" />
 
 Use this to confirm everything is wired up correctly (right term, right streams, right subjects) before committing to a full generation run.
 
@@ -207,6 +216,8 @@ Two print formats are available:
 - **Color Print** — full-colour A4 landscape with a legend.
 - **Standard Print** — clean black-and-white layout with abbreviated subject names, period numbers, and two-letter day abbreviations (classic school timetable style).
 
+<img width="1453" height="638" alt="TimeTableViewer" src="https://github.com/user-attachments/assets/75da346f-df13-4369-a7a5-a534950dd574" />
+
 **Diagnose Unscheduled** — when any items could not be placed, a Diagnose button appears on the result. It explains for each subject–stream group exactly why it failed:
 
 1. No teacher assigned to this subject for this stream.
@@ -215,6 +226,8 @@ Two print formats are available:
 4. Resource contention — teacher, room, and stream were simultaneously occupied in every remaining period.
 
 Each entry includes a suggested fix and a teacher workload table with colour-coded status badges.
+
+<img width="822" height="537" alt="Diagnose" src="https://github.com/user-attachments/assets/a207f5dd-3dc6-4dc1-b75b-4b033f78e97a" />
 
 ---
 

--- a/nl_school/junior_school_customization/page/school_timetable/school_timetable.js
+++ b/nl_school/junior_school_customization/page/school_timetable/school_timetable.js
@@ -1,282 +1,293 @@
 frappe.pages["school-timetable"].on_page_load = function (wrapper) {
-  var page = frappe.ui.make_app_page({
+  const page = frappe.ui.make_app_page({
     parent: wrapper,
-    title: "School Timetable",
+    title: __("School Timetable"),
     single_column: true,
   });
 
-  $(page.body).append(`
-        <div style="position: absolute; top: 10px; right: 20px;">
-            <button class="btn btn-success" id="btn-print">Print</button>
-        </div>
+  let calendar = null;
+  let streamColorMap = {};
+  let allTerms = [];
 
-        <div class="text-center p-3";">
-            <div class="d-flex flex-wrap justify-content-center gap-2 mt-2">
-                <div class="form-group mr-2" style="min-width: 150px;">
-                    <select id="level-dropdown" class="form-control">
-                        <option value="">All Levels</option>
-                        <option value="pre-primary">Pre-Primary</option>
-                        <option value="primary">Primary</option>
-                    </select>
-                </div>
+  // Color palette for streams — light background, colored border
+  const STREAM_COLORS = [
+    { bg: "#EFF6FF", border: "#3B82F6", text: "#1D4ED8" },
+    { bg: "#F0FDF4", border: "#16A34A", text: "#14532D" },
+    { bg: "#FFF7ED", border: "#EA580C", text: "#9A3412" },
+    { bg: "#FDF4FF", border: "#9333EA", text: "#6B21A8" },
+    { bg: "#FFF1F2", border: "#E11D48", text: "#9F1239" },
+    { bg: "#ECFDF5", border: "#0D9488", text: "#134E4A" },
+    { bg: "#EEF2FF", border: "#4F46E5", text: "#312E81" },
+    { bg: "#FFFBEB", border: "#D97706", text: "#78350F" },
+    { bg: "#F0F9FF", border: "#0284C7", text: "#0C4A6E" },
+    { bg: "#FDF2F8", border: "#DB2777", text: "#831843" },
+    { bg: "#F7FEE7", border: "#65A30D", text: "#365314" },
+    { bg: "#FFF5F5", border: "#DC2626", text: "#7F1D1D" },
+  ];
 
-                <div class="form-group mr-2" style="min-width: 150px;">
-                    <select id="teacher-dropdown" class="form-control">
-                        <option value="">All Teachers</option>
-                    </select>
-                </div>
+  function pickStreamColor(stream) {
+    if (!streamColorMap[stream]) {
+      const idx = Object.keys(streamColorMap).length % STREAM_COLORS.length;
+      streamColorMap[stream] = STREAM_COLORS[idx];
+    }
+    return streamColorMap[stream];
+  }
 
-                <div class="form-group mr-2" style="min-width: 150px;">
-                    <select id="stream-dropdown" class="form-control">
-                        <option value="">All Streams</option>
-                    </select>
-                </div>
+  function fmtTime(timeStr) {
+    if (!timeStr) return "";
+    const parts = String(timeStr).split(":");
+    let h = parseInt(parts[0]);
+    const m = (parts[1] || "00").substring(0, 2);
+    const ampm = h >= 12 ? "PM" : "AM";
+    h = h % 12 || 12;
+    return `${h}:${m} ${ampm}`;
+  }
 
-                <div>
-                    <button class="btn btn-primary" id="btn-reset">Clear Filters</button>
-                </div>
-            </div>
-        </div>
+  /**
+   * Convert a JS Date to a "YYYY-MM-DD" string using LOCAL date components.
+   */
+  function toLocalDateStr(date) {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, "0");
+    const d = String(date.getDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+  }
 
-        <div id="calendar"></div>
-        <div id="printable-timetable" class="d-none"></div>
+  function fmtTimeTo24(val) {
+    if (!val) return "00:00:00";
+    const parts = String(val).split(":");
+    return parts
+      .slice(0, 3)
+      .map((p) => p.padStart(2, "0"))
+      .join(":");
+  }
 
-        <!-- Edit/Create Schedule Modal -->
-        <div class="modal fade" id="scheduleModal" tabindex="-1" role="dialog" aria-labelledby="scheduleModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="scheduleModalLabel">Schedule</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                      <form id="schedule-form">
-                        <input type="hidden" id="schedule-id">
+  $(page.body).html(`
+		<div id="tt-page-wrap">
+			<!-- Filter bar -->
+			<div id="tt-filters" class="d-flex flex-wrap align-items-center gap-3 p-3"
+				style="border-bottom:1px solid var(--border-color); background:var(--card-bg);">
 
-                        <div class="form-row">
-                            <div class="form-group col-md-6">
-                                <label for="edit-course">Course</label>
-                                <select class="form-control" id="edit-course"></select>
-                            </div>
-                            <div class="form-group col-md-6">
-                                <label for="edit-instructor">Instructor</label>
-                                <select class="form-control" id="edit-instructor"></select>
-                            </div>
-                        </div>
+				<div class="d-flex align-items-center gap-2">
+					<label class="control-label mb-0 text-nowrap">${__("Term")}:</label>
+					<select id="tt-term" class="form-control form-control-sm" style="min-width:200px;">
+						<option value="">${__("All Terms")}</option>
+					</select>
+				</div>
 
-                        <div class="form-row">
-                            <div class="form-group col-md-6">
-                                <label for="edit-student-group">Student Group</label>
-                                <select class="form-control" id="edit-student-group"></select>
-                            </div>
-                            <div class="form-group col-md-6">
-                                <label for="edit-room">Room</label>
-                                <select class="form-control" id="edit-room"></select>
-                            </div>
-                        </div>
+				<div class="d-flex align-items-center gap-2">
+					<label class="control-label mb-0 text-nowrap">${__("Class")}:</label>
+					<select id="tt-stream" class="form-control form-control-sm" style="min-width:180px;">
+						<option value="">${__("All Classes")}</option>
+					</select>
+				</div>
 
-                        <div class="form-row">
-                            <div class="form-group col-md-6">
-                                <label for="edit-from-time">From Time</label>
-                                <input type="time" class="form-control" id="edit-from-time">
-                            </div>
+				<div class="d-flex align-items-center gap-2">
+					<label class="control-label mb-0 text-nowrap">${__("Teacher")}:</label>
+					<select id="tt-teacher" class="form-control form-control-sm" style="min-width:180px;">
+						<option value="">${__("All Teachers")}</option>
+					</select>
+				</div>
 
-                             <div class="form-group col-md-6">
-                                <label for="edit-to-time">To Time</label>
-                                <input type="time" class="form-control" id="edit-to-time">
-                            </div>
-                        </div>
+				<div class="d-flex gap-2 ml-auto">
+					<button id="tt-clear" class="btn btn-sm btn-default">${__("Clear")}</button>
+					<button id="tt-print" class="btn btn-sm btn-primary">${__("Print")}</button>
+				</div>
+			</div>
 
-                        <div class="form-row">
-                        <div class="form-group col-md-6">
-                                <label for="edit-date">Date</label>
-                                <input type="date" class="form-control" id="edit-date">
-                            </div>
-                        </div>
-                    </form>
+			<!-- Calendar -->
+			<div id="tt-calendar" style="padding:16px;"></div>
+		</div>
 
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                        <button type="button" class="btn btn-primary" id="save-schedule">Save</button>
-                    </div>
-                </div>
-            </div>
-        </div>
-    `);
+		<style>
+			#tt-calendar .fc { font-family: inherit; font-size: 13px; }
+			#tt-calendar .fc-toolbar-title {
+				font-size: 16px; font-weight: 600; color: var(--text-color);
+			}
+			#tt-calendar .fc-button {
+				background: var(--btn-default-bg, #f0f0f0);
+				border: 1px solid var(--border-color);
+				color: var(--text-color);
+				box-shadow: none !important;
+				padding: 4px 12px;
+				font-size: 12px;
+				border-radius: var(--border-radius, 4px);
+			}
+			#tt-calendar .fc-button:hover { background: var(--control-bg); }
+			#tt-calendar .fc-button-primary:not(:disabled).fc-button-active,
+			#tt-calendar .fc-button-primary:not(:disabled):active {
+				background: var(--primary) !important;
+				border-color: var(--primary) !important;
+				color: #fff !important;
+			}
+			#tt-calendar .fc-col-header-cell-cushion,
+			#tt-calendar .fc-daygrid-day-number { color: var(--text-color); text-decoration: none; }
+			#tt-calendar .fc-timegrid-slot { height: 48px; }
+			#tt-calendar .fc-timegrid-slot-label { font-size: 11px; color: var(--text-muted); }
+			#tt-calendar .fc-event {
+				border-radius: 4px; border-width: 2px; cursor: pointer; padding: 2px 4px;
+			}
+			#tt-calendar .fc-event:hover { filter: brightness(0.94); }
+			#tt-calendar .fc-day-today { background: rgba(249,200,0,0.07) !important; }
+			#tt-calendar .fc-col-header { background: #374151; }
+			#tt-calendar .fc-col-header-cell-cushion {
+				color: #fff !important; font-size: 12px; font-weight: 600; padding: 6px 8px;
+			}
+			#tt-calendar .fc-list-event:hover td { background: var(--control-bg); }
+		</style>
+	`);
 
-  let css_link = document.createElement("link");
-  css_link.rel = "stylesheet";
-  css_link.href =
-    "https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.css";
-  document.head.appendChild(css_link);
-
-  let script = document.createElement("script");
-  script.src = "https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.js";
-  script.onload = render_calendar;
-  document.head.appendChild(script);
-
-  let calendar;
-  let selectedFilter = null;
-  let selectedValue = "";
-  let selectedLevel = "";
-  let allTeachers = [];
-  let allStreams = [];
-  let allRooms = [];
-  let isNewSchedule = false;
-
-  let customStyles = document.createElement("style");
-  customStyles.innerHTML = `
-        /* Increase time row height */
-        .fc-timegrid-slot {
-            height: 60px !important; /* Adjust this value to your preference */
-        }
-    `;
-  document.head.appendChild(customStyles);
-
-  // Fetch teachers and populate dropdown
+  // Load dropdown data
   frappe.call({
     method:
-      "nl_school.junior_school_customization.page.school_timetable.timetable.get_teachers",
-    callback: function (response) {
-      allTeachers = response.message;
-      let teacherDropdown = $("#teacher-dropdown");
-      let editInstructorDropdown = $("#edit-instructor");
-
-      response.message.forEach((teacher) => {
-        teacherDropdown.append(
-          `<option value="${teacher.value}">${teacher.label}</option>`,
-        );
-        editInstructorDropdown.append(
-          `<option value="${teacher.value}">${teacher.label}</option>`,
-        );
-      });
+      "nl_school.junior_school_customization.page.school_timetable.timetable.get_academic_terms",
+    callback(r) {
+      allTerms = r.message || [];
+      const sel = $("#tt-term");
+      allTerms.forEach((t) =>
+        sel.append(`<option value="${t.value}">${t.label}</option>`),
+      );
     },
   });
 
-  // Fetch streams and populate dropdown
   frappe.call({
     method:
       "nl_school.junior_school_customization.page.school_timetable.timetable.get_streams",
-    callback: function (response) {
-      allStreams = response.message;
-      let streamDropdown = $("#stream-dropdown");
-      let editStudentGroupDropdown = $("#edit-student-group");
-
-      response.message.forEach((stream) => {
-        streamDropdown.append(
-          `<option value="${stream.value}">${stream.label}</option>`,
-        );
-        editStudentGroupDropdown.append(
-          `<option value="${stream.value}">${stream.label}</option>`,
-        );
-      });
+    callback(r) {
+      const sel = $("#tt-stream");
+      (r.message || []).forEach((s) =>
+        sel.append(`<option value="${s.value}">${s.label}</option>`),
+      );
     },
   });
 
   frappe.call({
     method:
-      "nl_school.junior_school_customization.page.school_timetable.timetable.get_rooms",
-    callback: function (response) {
-      allRooms = response.message;
-      let allRoomsDropdown = $("#edit-room");
-      response.message.forEach((room) => {
-        allRoomsDropdown.append(
-          `<option value="${room.value}">${room.label}</option>`,
-        );
-      });
+      "nl_school.junior_school_customization.page.school_timetable.timetable.get_teachers",
+    callback(r) {
+      const sel = $("#tt-teacher");
+      (r.message || []).forEach((t) =>
+        sel.append(`<option value="${t.value}">${t.label}</option>`),
+      );
     },
   });
 
-  //fetch courses
-  frappe.call({
-    method:
-      "nl_school.junior_school_customization.page.school_timetable.timetable.get_courses",
-    callback: function (response) {
-      console.log("Here", response);
-
-      let allCoursesDropdown = $("#edit-course");
-      response.message.forEach((course) => {
-        allCoursesDropdown.append(
-          `<option value="${course.value}">${course.label}</option>`,
-        );
-      });
-    },
-  });
-
-  function render_calendar(filter_by = null, filter_value = "") {
-    let calendarEl = document.getElementById("calendar");
-
-    if (calendar) {
-      calendar.destroy();
+  // Load FullCalendar 6
+  function loadFullCalendar(cb) {
+    if (window.FullCalendar) {
+      cb();
+      return;
     }
 
-    calendar = new FullCalendar.Calendar(calendarEl, {
+    if (!document.getElementById("fc-css")) {
+      const link = document.createElement("link");
+      link.id = "fc-css";
+      link.rel = "stylesheet";
+      link.href =
+        "https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.css";
+      document.head.appendChild(link);
+    }
+    const script = document.createElement("script");
+    script.src =
+      "https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js";
+    script.onload = cb;
+    script.onerror = () =>
+      frappe.msgprint({
+        title: __("Load Error"),
+        message: __(
+          "Could not load the calendar library. Check your internet connection.",
+        ),
+        indicator: "red",
+      });
+    document.head.appendChild(script);
+  }
+
+  loadFullCalendar(initCalendar);
+
+  // Calendar initialization
+  function initCalendar() {
+    const calEl = document.getElementById("tt-calendar");
+    if (calendar) {
+      calendar.destroy();
+      calendar = null;
+    }
+
+    calendar = new FullCalendar.Calendar(calEl, {
       initialView: "timeGridWeek",
       headerToolbar: {
         left: "prev,next today",
         center: "title",
-        right: "dayGridMonth,timeGridWeek,timeGridDay",
+        right: "timeGridWeek,timeGridDay,listWeek",
       },
-      slotDuration: "00:45:00",
-      slotMinTime: "06:00:00",
+      buttonText: {
+        today: __("Today"),
+        week: __("Week"),
+        day: __("Day"),
+        list: __("Agenda"),
+      },
+      weekends: false, // school is Mon–Fri
+      slotMinTime: "07:00:00",
       slotMaxTime: "18:00:00",
+      slotDuration: "00:30:00",
+      slotLabelInterval: "01:00:00",
       allDaySlot: false,
       nowIndicator: true,
-      editable: true,
-      eventClick: function (info) {
-        openEditModal(info.event.id);
+      editable: false, // read-only
+      selectable: false,
+      eventClick(info) {
+        showEventDetail(info.event);
       },
-      dateClick: function (info) {
-        openCreateModal(info.date);
+      eventContent(arg) {
+        const ep = arg.event.extendedProps;
+        return {
+          html: `<div style="overflow:hidden; padding:2px 3px;">
+						<div style="font-size:10px; opacity:.75; white-space:nowrap;">${arg.timeText}</div>
+						<div style="font-weight:700; font-size:11px; line-height:1.3; white-space:normal;">${ep.course || arg.event.title}</div>
+						${ep.student_group ? `<div style="font-size:10px; opacity:.85;">${ep.student_group}</div>` : ""}
+						${ep.room ? `<div style="font-size:10px; opacity:.7;">${ep.room}</div>` : ""}
+					</div>`,
+        };
       },
-      eventDrop: function (info) {
-        updateEventTime(info.event);
-      },
-      eventResize: function (info) {
-        updateEventTime(info.event);
-      },
-      events: function (fetchInfo, successCallback, failureCallback) {
+      events(fetchInfo, successCb, failureCb) {
+        const instructor = $("#tt-teacher").val() || "";
+        const stream = $("#tt-stream").val() || "";
+        const startDate = fetchInfo.startStr.split("T")[0];
+        const endDate = fetchInfo.endStr.split("T")[0];
+
         frappe.call({
           method:
             "nl_school.junior_school_customization.page.school_timetable.timetable.get_course_schedule",
-          args: {},
-          callback: function (response) {
-            let events = response.message
-              .filter((event) => {
-                if (filter_by === "instructor" && filter_value) {
-                  return event.instructor
-                    .toLowerCase()
-                    .includes(filter_value.toLowerCase());
-                } else if (filter_by === "stream" && filter_value) {
-                  return event.student_group
-                    .toLowerCase()
-                    .includes(filter_value.toLowerCase());
-                }
-                return true;
-              })
-              .map((event) => ({
-                id: event.name,
-                title: `${event.course} - ${event.instructor}`,
-                start: `${event.schedule_date}T${event.from_time}`,
-                end: `${event.schedule_date}T${event.to_time}`,
-                backgroundColor:
-                  event.course.includes("Break") ||
-                  event.course.includes("Lunch")
-                    ? "#f8d7da"
-                    : "#007bff",
-                extendedProps: {
-                  course: event.course,
-                  instructor: event.instructor,
-                  student_group: event.student_group,
-                  room: event.room,
-                  program: event.program,
-                },
-              }));
-            successCallback(events);
+          args: {
+            instructor,
+            stream,
+            start_date: startDate,
+            end_date: endDate,
           },
+          callback(r) {
+            const events = (r.message || []).map((s) => {
+              const col = pickStreamColor(s.student_group);
+              return {
+                id: s.name,
+                title: s.course,
+                start: `${s.schedule_date}T${fmtTimeTo24(s.from_time)}`,
+                end: `${s.schedule_date}T${fmtTimeTo24(s.to_time)}`,
+                backgroundColor: col.bg,
+                borderColor: col.border,
+                textColor: col.text,
+                extendedProps: {
+                  course: s.course,
+                  instructor: s.instructor,
+                  student_group: s.student_group,
+                  room: s.room,
+                  schedule_date: s.schedule_date,
+                  from_time: s.from_time,
+                  to_time: s.to_time,
+                },
+              };
+            });
+            successCb(events);
+          },
+          error: failureCb,
         });
       },
     });
@@ -284,425 +295,206 @@ frappe.pages["school-timetable"].on_page_load = function (wrapper) {
     calendar.render();
   }
 
-  function openEditModal(scheduleId) {
-    isNewSchedule = false;
-
-    $("#scheduleModalLabel").text("Edit Schedule");
-
-    frappe.call({
-      method:
-        "nl_school.junior_school_customization.page.school_timetable.timetable.get_course_schedule_details",
-      args: { schedule_name: scheduleId },
-      callback: function (response) {
-        const schedule = response.message;
-        if (schedule) {
-          const formattedDate = schedule.schedule_date;
-
-          $("#schedule-id").val(schedule.name);
-          $("#edit-course").val(schedule.course);
-          $("#edit-instructor").val(schedule.instructor);
-          $("#edit-student-group").val(schedule.student_group);
-          $("#edit-room").val(schedule.room);
-          $("#edit-date").val(formattedDate);
-          $("#edit-from-time").val(schedule.from_time);
-          $("#edit-to-time").val(schedule.to_time);
-
-          $("#scheduleModal").modal("show");
-        } else {
-          frappe.throw(__("Failed to retrieve schedule details"));
-        }
-      },
+  // event detail popup
+  function showEventDetail(event) {
+    const ep = event.extendedProps;
+    const col = pickStreamColor(ep.student_group);
+    frappe.msgprint({
+      title: ep.course,
+      message: `
+				<table class="table table-bordered table-sm" style="margin:0;">
+					<tr><th style="width:110px;">${__("Date")}</th>
+					    <td>${ep.schedule_date || ""}</td></tr>
+					<tr><th>${__("Time")}</th>
+					    <td>${fmtTime(ep.from_time)} – ${fmtTime(ep.to_time)}</td></tr>
+					<tr><th>${__("Class")}</th>
+					    <td><span style="display:inline-block; padding:2px 8px; border-radius:3px;
+					        background:${col.bg}; border:1px solid ${col.border};
+					        color:${col.text}; font-weight:600;">${ep.student_group || "-"}
+					    </span></td></tr>
+					<tr><th>${__("Teacher")}</th><td>${ep.instructor || "-"}</td></tr>
+					<tr><th>${__("Room")}</th>  <td>${ep.room || "-"}</td></tr>
+				</table>`,
+      indicator: "blue",
     });
   }
 
-  function openCreateModal(date) {
-    isNewSchedule = true;
-
-    $("#scheduleModalLabel").text("Create New Schedule");
-
-    const formattedDate = date.toISOString().split("T")[0];
-
-    let hours = date.getHours().toString().padStart(2, "0");
-    let minutes = date.getMinutes().toString().padStart(2, "0");
-    const clickTime = `${hours}:${minutes}`;
-
-    const endDate = new Date(date);
-    endDate.setMinutes(endDate.getMinutes() + 45);
-    let endHours = endDate.getHours().toString().padStart(2, "0");
-    let endMinutes = endDate.getMinutes().toString().padStart(2, "0");
-    const endTime = `${endHours}:${endMinutes}`;
-
-    $("#schedule-id").val("");
-    $("#edit-course").val("");
-    $("#edit-instructor").val("");
-    $("#edit-student-group").val("");
-    $("#edit-room").val("");
-    $("#edit-date").val(formattedDate);
-    $("#edit-from-time").val(`${clickTime}:00`);
-    $("#edit-to-time").val(`${endTime}:00`);
-
-    $("#scheduleModal").modal("show");
+  // Filter
+  function refetch() {
+    if (calendar) calendar.refetchEvents();
   }
 
-  // Update event time after drag/resize
-  function updateEventTime(event) {
-    const startTime = event.start.toISOString().split("T")[1].substring(0, 8);
-    const endTime = event.end.toISOString().split("T")[1].substring(0, 8);
-    const scheduleDate = event.start.toISOString().split("T")[0];
-
-    frappe.call({
-      method:
-        "nl_school.junior_school_customization.page.school_timetable.timetable.update_course_schedule",
-      args: {
-        schedule_name: event.id,
-        schedule_date: scheduleDate,
-        from_time: startTime,
-        to_time: endTime,
-      },
-      callback: function (response) {
-        if (response.message === "success") {
-          frappe.show_alert(
-            {
-              message: __("Schedule updated successfully"),
-              indicator: "green",
-            },
-            3,
-          );
-        } else {
-          frappe.show_alert(
-            {
-              message: __("Failed to update schedule"),
-              indicator: "red",
-            },
-            3,
-          );
-          calendar.refetchEvents();
-        }
-      },
-    });
-  }
-
-  // Save schedule changes or create new
-  $("#save-schedule").on("click", function () {
-    const scheduleId = $("#schedule-id").val();
-    const course = $("#edit-course").val();
-    const instructor = $("#edit-instructor").val();
-    const studentGroup = $("#edit-student-group").val();
-    const room = $("#edit-room").val();
-    const scheduleDate = $("#edit-date").val();
-    const fromTime = $("#edit-from-time").val();
-    const toTime = $("#edit-to-time").val();
-
-    // Validate form
-    if (
-      !course ||
-      !instructor ||
-      !studentGroup ||
-      !scheduleDate ||
-      !fromTime ||
-      !toTime
-    ) {
-      frappe.msgprint(__("Please fill in all required fields"));
-      return;
-    }
-
-    if (isNewSchedule) {
-      // Create new schedule
-      frappe.call({
-        method:
-          "nl_school.junior_school_customization.page.school_timetable.timetable.create_course_schedule",
-        args: {
-          course: course,
-          instructor: instructor,
-          student_group: studentGroup,
-          room: room,
-          schedule_date: scheduleDate,
-          from_time: fromTime,
-          to_time: toTime,
-        },
-        callback: function (response) {
-          if (response.message && response.message !== "error") {
-            $("#scheduleModal").modal("hide");
-            frappe.show_alert(
-              {
-                message: __("Schedule created successfully"),
-                indicator: "green",
-              },
-              3,
-            );
-            // Refresh calendar events
-            calendar.refetchEvents();
-          } else {
-            frappe.show_alert(
-              {
-                message: __("Failed to create schedule"),
-                indicator: "red",
-              },
-              3,
-            );
-          }
-        },
-      });
-    } else {
-      // Update existing schedule
-      frappe.call({
-        method:
-          "nl_school.junior_school_customization.page.school_timetable.timetable.update_course_schedule_details",
-        args: {
-          schedule_name: scheduleId,
-          course: course,
-          instructor: instructor,
-          student_group: studentGroup,
-          room: room,
-          schedule_date: scheduleDate,
-          from_time: fromTime,
-          to_time: toTime,
-        },
-        callback: function (response) {
-          if (response.message === "success") {
-            $("#scheduleModal").modal("hide");
-            frappe.show_alert(
-              {
-                message: __("Schedule updated successfully"),
-                indicator: "green",
-              },
-              3,
-            );
-            // Refresh calendar events
-            calendar.refetchEvents();
-          } else {
-            frappe.show_alert(
-              {
-                message: __("Failed to update schedule"),
-                indicator: "red",
-              },
-              3,
-            );
-          }
-        },
-      });
-    }
+  $("#tt-term").on("change", function () {
+    const term = allTerms.find((t) => t.value === $(this).val());
+    if (term && term.start && calendar) calendar.gotoDate(term.start);
+    refetch();
   });
 
-  $("#btn-reset").on("click", function () {
-    $("#level-dropdown").val("");
-    $("#teacher-dropdown").val("");
-    $("#stream-dropdown").val("");
-    selectedLevel = "";
-    selectedFilter = null;
-    selectedValue = "";
-    render_calendar();
+  $("#tt-stream").on("change", refetch);
+  $("#tt-teacher").on("change", refetch);
+
+  $("#tt-clear").on("click", function () {
+    $("#tt-term, #tt-stream, #tt-teacher").val("");
+    streamColorMap = {};
+    refetch();
   });
 
-  $("#level-dropdown").on("change", function () {
-    selectedLevel = $(this).val();
-  });
+  // Print
+  $("#tt-print").on("click", function () {
+    if (!calendar) return;
 
-  $("#teacher-dropdown").on("change", function () {
-    let selectedTeacher = $(this).val();
-    if (selectedTeacher) {
-      selectedFilter = "instructor";
-      selectedValue = selectedTeacher;
-      $("#stream-dropdown").val("");
-    } else {
-      selectedFilter = null;
-      selectedValue = "";
-    }
-    render_calendar(selectedFilter, selectedValue);
-  });
+    const viewStart = new Date(calendar.view.currentStart);
+    const viewEndExcl = new Date(calendar.view.currentEnd);
+    viewEndExcl.setDate(viewEndExcl.getDate() - 1);
 
-  $("#stream-dropdown").on("change", function () {
-    let selectedStream = $(this).val();
-    if (selectedStream) {
-      selectedFilter = "stream";
-      selectedValue = selectedStream;
-      $("#teacher-dropdown").val("");
-    } else {
-      selectedFilter = null;
-      selectedValue = "";
-    }
-    render_calendar(selectedFilter, selectedValue);
-  });
+    const startDate = toLocalDateStr(viewStart);
+    const endDate = toLocalDateStr(viewEndExcl);
+    const instructor = $("#tt-teacher").val() || "";
+    const stream = $("#tt-stream").val() || "";
 
-  document.getElementById("btn-print").addEventListener("click", function () {
-    generatePrintableTimetable(selectedFilter, selectedValue);
-  });
-
-  function generatePrintableTimetable(filter_type, filter_value) {
     frappe.call({
       method:
         "nl_school.junior_school_customization.page.school_timetable.timetable.get_course_schedule",
-      args: { [filter_type]: filter_value },
-      callback: function (response) {
-        let schedules = response.message;
-
-        let weekdays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
-
-        // Pre-Primary time slots
-        let prePrimaryTimeSlots = [
-          { start: "7:40 AM", end: "8:15 AM", label: "Breakfast" },
-          { start: "8:15 AM", end: "9:00 AM" },
-          { start: "9:00 AM", end: "9:45 AM" },
-          { start: "9:45 AM", end: "10:30 AM", label: "First Break" },
-          { start: "10:30 AM", end: "11:15 AM" },
-          { start: "11:15 AM", end: "11:30 AM" },
-          { start: "11:30 AM", end: "11:45 AM", label: "Second Break" },
-          { start: "11:45 AM", end: "12:30 PM" },
-          { start: "12:30 PM", end: "1:20 PM", label: "Lunch" },
-          { start: "1:20 PM", end: "2:15 PM" },
-          { start: "2:15 PM", end: "3:00 PM" },
-        ];
-
-        let primaryTimeSlots = [
-          { start: "6:45 AM", end: "7:40 AM" },
-          { start: "7:40 AM", end: "8:10 AM", label: "Breakfast" },
-          { start: "8:10 AM", end: "8:55 AM" },
-          { start: "8:55 AM", end: "9:40 AM" },
-          { start: "9:40 AM", end: "9:50 AM", label: "First Break" },
-          { start: "9:50 AM", end: "10:35 AM" },
-          { start: "10:35 AM", end: "11:20 AM" },
-          { start: "11:20 AM", end: "11:30 AM", label: "Second Break" },
-          { start: "11:30 AM", end: "12:15 PM" },
-          { start: "12:15 PM", end: "1:00 PM" },
-          { start: "1:00 PM", end: "1:45 PM", label: "Lunch" },
-          { start: "1:45 PM", end: "1:55 PM" },
-          { start: "1:55 PM", end: "2:40 PM" },
-          { start: "2:40 PM", end: "3:25 PM" },
-          { start: "3:25 PM", end: "4:10 PM" },
-        ];
-
-        let timeSlots =
-          selectedLevel === "pre-primary"
-            ? prePrimaryTimeSlots
-            : primaryTimeSlots;
-
-        let showInstructor = filter_type === "stream";
-        let showStudentGroup = filter_type === "instructor";
-
-        let title = filter_value
-          ? `${filter_value} Timetable`
-          : "School Timetable";
-        if (selectedLevel) {
-          title = `${selectedLevel.charAt(0).toUpperCase() + selectedLevel.slice(1)} School ${title}`;
-        }
-
-        let tableHTML = `
-                <h3 class="text-center">${title}</h3>
-                <div style="display: flex; justify-content: center; overflow-x: auto;">
-                    <table class="table table-bordered" style="table-layout: fixed; width: auto; margin: auto;">
-                        <thead>
-                            <tr>
-                                <th style="width: 100px; text-align: center;">Day</th>
-                                ${timeSlots
-                                  .map(
-                                    (slot) => `
-                                    <th style="width: 150px; min-height: 80px; text-align: center; vertical-align: middle; font-size: 12px; font-weight: normal;">
-                                        ${slot.label ? `${removeAMPM(slot.start)} - ${removeAMPM(slot.end)}<br>(${slot.label})` : `${slot.start} - ${slot.end}`}
-                                    </th>`,
-                                  )
-                                  .join("")}
-                            </tr>
-                        </thead>
-                        <tbody>
-                `;
-
-        weekdays.forEach((day) => {
-          tableHTML += `<tr><td>${day}</td>`;
-
-          timeSlots.forEach((slot) => {
-            // Check if this slot is a predefined break or meal time
-            if (slot.label) {
-              tableHTML += `<td class="text-center" style="background-color: #f8d7da; font-size: 12px;">${slot.label}</td>`;
-              return;
-            }
-
-            let matchedSchedule = schedules.find((schedule) => {
-              let scheduleDay = new Date(schedule.schedule_date)
-                .toLocaleDateString("en-US", { weekday: "long" })
-                .trim();
-              let scheduleTime = convertTo12HourFormat(schedule.from_time);
-
-              return scheduleDay === day && scheduleTime === slot.start;
-            });
-
-            if (matchedSchedule) {
-              let displayText = "";
-
-              if (showInstructor) {
-                displayText = `${matchedSchedule.course} - <span style="color: blue;">${matchedSchedule.instructor}</span>`;
-              } else if (showStudentGroup) {
-                displayText = `${matchedSchedule.course} - <span style="color: green;">${matchedSchedule.student_group}</span>`;
-              } else {
-                displayText = matchedSchedule.course;
-              }
-
-              tableHTML += `<td>${displayText}</td>`;
-            } else {
-              tableHTML += `<td></td>`;
-            }
-          });
-
-          tableHTML += `</tr>`;
-        });
-
-        tableHTML += `</tbody></table></div>`;
-
-        let printableDiv = document.getElementById("printable-timetable");
-        printableDiv.innerHTML = tableHTML;
-        printableDiv.classList.remove("d-none");
-        printTimetable();
+      args: {
+        instructor,
+        stream,
+        start_date: startDate,
+        end_date: endDate,
+      },
+      callback(r) {
+        printSchedule(
+          r.message || [],
+          stream || instructor || __("All"),
+          startDate,
+          endDate,
+        );
       },
     });
-  }
+  });
 
-  // Function to remove AM/PM from time labels
-  function removeAMPM(timeString) {
-    return timeString.replace(/\s?(AM|PM)/g, "");
-  }
+  function printSchedule(schedules, label, startDate, endDate) {
+    // Build the list of dates that are actually in the queried range
+    // (Mon–Fri only) so a day-view prints one day,
+    // a week-view prints Mon–Fri, etc.
+    const displayDates = [];
+    const cur = new Date(startDate + "T12:00:00");
+    const end = new Date(endDate + "T12:00:00");
+    while (cur <= end) {
+      const dow = cur.getDay();
+      if (dow >= 1 && dow <= 5) {
+        // Mon = 1 … Fri = 5
+        displayDates.push(cur.toISOString().split("T")[0]);
+      }
+      cur.setDate(cur.getDate() + 1);
+    }
 
-  // Function to convert time to 12-hour format
-  function convertTo12HourFormat(timeString) {
-    let timeParts = timeString.split(":");
-    let hours = parseInt(timeParts[0], 10);
-    let minutes = timeParts.length > 1 ? timeParts[1] : "00";
+    // Group schedules by date
+    const byDate = {};
+    displayDates.forEach((d) => (byDate[d] = []));
+    schedules.forEach((s) => {
+      if (byDate[s.schedule_date]) byDate[s.schedule_date].push(s);
+    });
 
-    let period = hours >= 12 ? "PM" : "AM";
-    hours = hours % 12 || 12;
-    return `${hours}:${minutes} ${period}`;
-  }
+    // Unique sorted time slots from the returned data
+    const slotMap = {};
+    schedules.forEach((s) => {
+      const key = fmtTimeTo24(s.from_time);
+      slotMap[key] = { from: s.from_time, to: s.to_time };
+    });
+    const slots = Object.keys(slotMap)
+      .sort()
+      .map((k) => slotMap[k]);
 
-  // Print function
-  function printTimetable() {
-    let printContent = document.getElementById("printable-timetable").innerHTML;
-    let newWindow = window.open("", "", "width=1000,height=800");
-    newWindow.document.write(`
-            <html>
-            <head>
-                <title>School Timetable</title>
-                <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
-                <style>
-                    @media print {
-                        .table th, .table td {
-                            padding: 8px;
-                            border: 1px solid #ddd;
-                        }
-                        table {
-                            width: 100% !important;
-                            table-layout: fixed;
-                        }
-                        th, td {
-                            font-size: 10px;
-                            padding: 4px !important;
-                        }
-                    }
-                </style>
-            </head>
-            <body class="container-fluid mt-3">
-                ${printContent}
-            </body>
-            </html>
-        `);
-    newWindow.document.close();
-    newWindow.print();
+    if (!slots.length || !displayDates.length) {
+      frappe.msgprint({
+        title: __("Nothing to Print"),
+        message: __("No schedules found for the current view."),
+        indicator: "orange",
+      });
+      return;
+    }
+
+    const colHeaders = slots
+      .map(
+        (sl) =>
+          `<th style="text-align:center; font-size:10px; padding:4px 3px; background:#f0f0f0; white-space:nowrap;">
+						${fmtTime(sl.from)}<br><span style="opacity:.65;">– ${fmtTime(sl.to)}</span>
+					</th>`,
+      )
+      .join("");
+
+    const rows = displayDates
+      .map((dateStr) => {
+        // Header cell: "Mon\n19 May"
+        const d = new Date(dateStr + "T12:00:00");
+        const dayAbbr = d.toLocaleDateString("en-US", {
+          weekday: "short",
+        });
+        const dateFmt = d.toLocaleDateString("en-US", {
+          day: "numeric",
+          month: "short",
+        });
+
+        const cells = slots
+          .map((sl) => {
+            // Use filter (not find) so ALL classes at this time are shown,
+            // including parallel classes in different streams.
+            const matches = (byDate[dateStr] || []).filter(
+              (s) => fmtTimeTo24(s.from_time) === fmtTimeTo24(sl.from),
+            );
+            if (!matches.length)
+              return `<td style="border:1px solid #ccc; padding:4px;"></td>`;
+
+            const blocks = matches
+              .map(
+                (m, idx) => `
+								<div style="${idx > 0 ? "border-top:1px dashed #ccc; margin-top:3px; padding-top:3px;" : ""}">
+									<strong style="font-size:11px;">${m.course}</strong><br>
+									<span style="font-size:10px; color:#444;">${m.instructor || ""}</span><br>
+									<span style="font-size:10px; color:#777;">
+										${m.student_group || ""}${m.room ? " · " + m.room : ""}
+									</span>
+								</div>`,
+              )
+              .join("");
+
+            return `<td style="border:1px solid #ccc; padding:4px; vertical-align:top;">${blocks}</td>`;
+          })
+          .join("");
+
+        return `<tr>
+					<td style="border:1px solid #ccc; padding:5px 7px; font-weight:700;
+						font-size:12px; background:#f8f8f8; white-space:nowrap; text-align:center;">
+						${dayAbbr}<br><span style="font-weight:400; font-size:10px;">${dateFmt}</span>
+					</td>
+					${cells}
+				</tr>`;
+      })
+      .join("");
+
+    const html = `<!DOCTYPE html><html><head><meta charset="utf-8">
+			<title>${__("Timetable")} — ${label}</title>
+			<style>
+				body { font-family: Arial, sans-serif; margin: 12px; }
+				h2 { font-size: 14px; text-align: center; margin-bottom: 10px; }
+				table { border-collapse: collapse; width: 100%; }
+				th { border: 1px solid #ccc; padding: 5px; }
+				@media print { @page { size: A4 landscape; margin: 8mm; } }
+			</style></head><body>
+			<h2>${__("Timetable")} — ${label}</h2>
+			<table>
+				<thead><tr>
+					<th style="width:46px; background:#374151; color:#fff;">${__("Day")}</th>
+					${colHeaders}
+				</tr></thead>
+				<tbody>${rows}</tbody>
+			</table>
+		</body></html>`;
+
+    const win = window.open("", "_blank");
+    win.document.write(html);
+    win.document.close();
+    win.focus();
+    win.print();
   }
 };

--- a/nl_school/junior_school_customization/page/school_timetable/timetable.py
+++ b/nl_school/junior_school_customization/page/school_timetable/timetable.py
@@ -2,15 +2,22 @@ import frappe
 
 
 @frappe.whitelist()
-def get_course_schedule(instructor=None, stream=None):
+def get_course_schedule(instructor=None, stream=None, start_date=None, end_date=None):
+    """
+    Fetch Course Schedule records for the given date range.
+    Supports filtering by instructor and/or student group.
+    A date range is required to avoid pulling the entire schedule history.
+    """
     filters = {}
 
     if instructor:
-        filters["instructor"] = ["like", f"%{instructor}%"]
+        filters["instructor"] = instructor
     if stream:
-        filters["student_group"] = ["like", f"%{stream}%"]
+        filters["student_group"] = stream
+    if start_date and end_date:
+        filters["schedule_date"] = ["between", [start_date, end_date]]
 
-    schedules = frappe.get_all(
+    return frappe.get_all(
         "Course Schedule",
         filters=filters,
         fields=[
@@ -22,41 +29,134 @@ def get_course_schedule(instructor=None, stream=None):
             "from_time",
             "to_time",
             "room",
-            "program",
         ],
+        order_by="schedule_date ASC, from_time ASC",
+        limit=2000,
     )
-    return schedules
 
 
 @frappe.whitelist()
 def get_course_schedule_details(schedule_name):
-    """Get all details of a specific course schedule."""
+    """Get full details of a specific Course Schedule record."""
     if not schedule_name:
         return None
-
     return frappe.get_doc("Course Schedule", schedule_name)
+
+
+@frappe.whitelist()
+def get_teachers():
+    """Fetch all instructors."""
+    teachers = frappe.get_all(
+        "Instructor",
+        fields=["name", "instructor_name"],
+        order_by="instructor_name ASC",
+    )
+    return [{"value": t.name, "label": t.instructor_name or t.name} for t in teachers]
+
+
+@frappe.whitelist()
+def get_streams():
+    """Fetch all student groups."""
+    streams = frappe.get_all(
+        "Student Group",
+        fields=["name"],
+        order_by="name ASC",
+    )
+    return [{"value": s.name, "label": s.name} for s in streams]
+
+
+@frappe.whitelist()
+def get_academic_terms():
+    """Fetch all academic terms with their date bounds for calendar navigation."""
+    terms = frappe.get_all(
+        "Academic Term",
+        fields=["name", "term_start_date", "term_end_date"],
+        order_by="term_start_date DESC",
+    )
+    return [
+        {
+            "value": t.name,
+            "label": t.name,
+            "start": str(t.term_start_date) if t.term_start_date else None,
+            "end": str(t.term_end_date) if t.term_end_date else None,
+        }
+        for t in terms
+    ]
+
+
+@frappe.whitelist()
+def get_rooms():
+    """Fetch all rooms."""
+    rooms = frappe.get_all(
+        "Room", fields=["name", "room_name"], order_by="room_name ASC"
+    )
+    return [{"value": r.name, "label": r.room_name or r.name} for r in rooms]
+
+
+@frappe.whitelist()
+def get_courses():
+    """Fetch all courses."""
+    courses = frappe.get_all(
+        "Course", fields=["name", "course_name"], order_by="course_name ASC"
+    )
+    return [{"value": c.name, "label": c.course_name or c.name} for c in courses]
+
+
+@frappe.whitelist()
+def create_course_schedule(
+    course,
+    instructor,
+    student_group,
+    room=None,
+    schedule_date=None,
+    from_time=None,
+    to_time=None,
+):
+    """Create a new Course Schedule."""
+    try:
+        if not all(
+            [course, instructor, student_group, schedule_date, from_time, to_time]
+        ):
+            return "error"
+
+        doc = frappe.new_doc("Course Schedule")
+        doc.course = course
+        doc.instructor = instructor
+        doc.student_group = student_group
+        doc.schedule_date = schedule_date
+        doc.from_time = from_time
+        doc.to_time = to_time
+
+        if room:
+            doc.room = room
+
+        sg = frappe.get_doc("Student Group", student_group)
+        if sg and sg.program:
+            doc.program = sg.program
+
+        doc.insert()
+        frappe.db.commit()
+        return doc.name
+    except Exception as e:
+        frappe.log_error(f"Failed to create course schedule: {str(e)}")
+        return "error"
 
 
 @frappe.whitelist()
 def update_course_schedule(
     schedule_name, schedule_date=None, from_time=None, to_time=None
 ):
-    """Update time and date of course schedule after drag/resize."""
+    """Update time/date after drag or resize."""
     try:
         if not schedule_name:
             return "error"
-
         doc = frappe.get_doc("Course Schedule", schedule_name)
-
         if schedule_date:
             doc.schedule_date = schedule_date
-
         if from_time:
             doc.from_time = from_time
-
         if to_time:
             doc.to_time = to_time
-
         doc.save()
         frappe.db.commit()
         return "success"
@@ -76,113 +176,28 @@ def update_course_schedule_details(
     from_time=None,
     to_time=None,
 ):
-    """Update all details of a course schedule from the edit modal."""
+    """Update all fields of a Course Schedule."""
     try:
         if not schedule_name:
             return "error"
-
         doc = frappe.get_doc("Course Schedule", schedule_name)
-
         if course:
             doc.course = course
-
         if instructor:
             doc.instructor = instructor
-
         if student_group:
             doc.student_group = student_group
-
         if room:
             doc.room = room
-
         if schedule_date:
             doc.schedule_date = schedule_date
-
         if from_time:
             doc.from_time = from_time
-
         if to_time:
             doc.to_time = to_time
-
         doc.save()
         frappe.db.commit()
         return "success"
     except Exception as e:
         frappe.log_error(f"Failed to update course schedule details: {str(e)}")
-        return "error"
-
-
-@frappe.whitelist()
-def get_teachers():
-    """Fetch all teachers."""
-    teachers = frappe.get_all("Instructor", fields=["name", "instructor_name"])
-    return [{"value": t.name, "label": t.instructor_name} for t in teachers]
-
-
-@frappe.whitelist()
-def get_streams():
-    """Fetch all streams."""
-    streams = frappe.get_all("Student Group", fields=["name", "program"])
-    return [{"value": s.name, "label": s.program} for s in streams]
-
-
-@frappe.whitelist()
-def get_rooms():
-    """Fetch all rooms."""
-    rooms = frappe.get_all("Room", fields=["name", "room_name"])
-    return [{"value": r.name, "label": r.room_name} for r in rooms]
-
-
-@frappe.whitelist()
-def get_courses():
-    """Fetch all courses."""
-    courses = frappe.get_all("Course", fields=["name", "course_name"])
-    return [{"value": c.name, "label": c.course_name} for c in courses]
-
-
-@frappe.whitelist()
-def create_course_schedule(
-    course,
-    instructor,
-    student_group,
-    room=None,
-    schedule_date=None,
-    from_time=None,
-    to_time=None,
-):
-    """Create a new course schedule."""
-    try:
-        # Validate required fields
-        if (
-            not course
-            or not instructor
-            or not student_group
-            or not schedule_date
-            or not from_time
-            or not to_time
-        ):
-            return "error"
-
-        # Create a new document
-        doc = frappe.new_doc("Course Schedule")
-        doc.course = course
-        doc.instructor = instructor
-        doc.student_group = student_group
-        doc.schedule_date = schedule_date
-        doc.from_time = from_time
-        doc.to_time = to_time
-
-        if room:
-            doc.room = room
-
-        # For example, you could get program from student_group
-        student_group_doc = frappe.get_doc("Student Group", student_group)
-        if student_group_doc and student_group_doc.program:
-            doc.program = student_group_doc.program
-
-        doc.insert()
-        frappe.db.commit()
-        return doc.name
-    except Exception as e:
-        frappe.log_error(f"Failed to create course schedule: {str(e)}")
         return "error"


### PR DESCRIPTION
## school timetable view and update docs

- Rebuild calendar with FullCalendar 6 — read-only, Mon–Fri, colour-coded by stream
- Add Academic Term, Class, and Teacher filters (all combinable)
- Fetch only the visible date range; fix print to match exactly what is on screen
- Fix get_streams label (was null when program unset); add get_academic_terms endpoint
- Update README: rewrite timetable sections with tables, filter behaviour, and print details