### PR TITLE
Feat/enhance timetable

### DIFF
--- a/nl_school/junior_school_customization/doctype/timetable_generation_result/timetable_generation_result.js
+++ b/nl_school/junior_school_customization/doctype/timetable_generation_result/timetable_generation_result.js
@@ -282,8 +282,10 @@ function generateStandardPrintHtml(data, viewMode, filterValue, title, opts) {
     .tt-subject{font-size:15px;font-weight:bold;line-height:1.1;}
     .tt-meta{display:flex;justify-content:space-between;font-size:8px;color:#333;margin-top:1px;}
     .tt-divider{border:none;border-top:1px dashed #aaa;margin:3px 0;}
+    .tt-letterhead{margin-bottom:8px;}
     @media print{@page{size:A4 landscape;margin:8mm;}}
   </style></head><body>
+  ${opts.letterHeadHtml ? `<div class="tt-letterhead">${opts.letterHeadHtml}</div>` : ""}
   <h2>${title}</h2>
   <table>
     <thead><tr>
@@ -400,8 +402,10 @@ function generateColorPrintHtml(data, viewMode, filterValue, colorMap, title, op
     body{font-family:Arial,sans-serif;margin:12px;font-size:10px;}
     h2{font-size:13px;text-align:center;margin-bottom:10px;}
     table{border-collapse:collapse;width:100%;}
+    .tt-letterhead{margin-bottom:8px;}
     @media print{@page{size:A4 landscape;margin:8mm;}}
   </style></head><body>
+  ${opts.letterHeadHtml ? `<div class="tt-letterhead">${opts.letterHeadHtml}</div>` : ""}
   <h2>${title}</h2>
   <table>
     <thead><tr>
@@ -466,6 +470,14 @@ frappe.ui.form.on("Timetable Generation Result", {
 
 // Collect per-print display preferences, then hand them to the generator.
 function openPrintOptions(onConfirm) {
+  const finish = (v, letterHeadHtml) =>
+    onConfirm({
+      fullNames: v.name_style === "Full",
+      showTeacher: !!v.show_teacher,
+      showRoom: !!v.show_room,
+      letterHeadHtml: letterHeadHtml || "",
+    });
+
   const d = new frappe.ui.Dialog({
     title: __("Print Options"),
     fields: [
@@ -489,17 +501,32 @@ function openPrintOptions(onConfirm) {
         fieldtype: "Check",
         default: 1,
       },
+      { fieldname: "sb", fieldtype: "Section Break" },
+      {
+        fieldname: "letter_head",
+        label: __("Letter Head"),
+        fieldtype: "Link",
+        options: "Letter Head",
+        description: __("Leave blank to print without a letter head."),
+      },
     ],
     primary_action_label: __("Print"),
     primary_action(v) {
       d.hide();
-      onConfirm({
-        fullNames: v.name_style === "Full",
-        showTeacher: !!v.show_teacher,
-        showRoom: !!v.show_room,
-      });
+      if (!v.letter_head) return finish(v, "");
+      frappe.db
+        .get_value("Letter Head", v.letter_head, "content")
+        .then((r) => finish(v, (r.message && r.message.content) || ""));
     },
   });
+
+  // Default to the site's default letter head, if any.
+  frappe.db
+    .get_value("Letter Head", { is_default: 1 }, "name")
+    .then((r) => {
+      if (r.message && r.message.name) d.set_value("letter_head", r.message.name);
+    });
+
   d.show();
 }
 

--- a/nl_school/public/js/assessment_result_tool.js
+++ b/nl_school/public/js/assessment_result_tool.js
@@ -1,11 +1,236 @@
-frappe.ui.form.on("Assessment Result Tool", {
-  onload: function (frm) {
-    frm.set_query("assessment_plan", function () {
-      return {
-        filters: {
-          status: "Open",
-        },
-      };
-    });
-  },
+// Customizations for the Education "Assessment Result Tool".
+//
+// Template mirrors education/public/js/assessment_result_tool.html with one
+// extra trailing column for the percentage (score / max total * 100).
+const NL_ASSESSMENT_RESULT_TEMPLATE = `
+<table class="table table-bordered assessment-result-tool">
+	<thead>
+		<tr>
+			<th style="width: 90px" rowspan="2">Student</th>
+			<th style="width: 170px" rowspan="2">Student Name</th>
+			{% for c in criteria %}
+			<th class="score" style="width: 100px">{{ c.assessment_criteria }}</th>
+			{% endfor %}
+			<th class="score" style="width: 170px" rowspan="2">Comments</th>
+			<th class="score" style="width: 100px">Total Marks</th>
+			<th class="score" style="width: 90px" rowspan="2">Out of 100</th>
+		</tr>
+		<tr>
+			{% for c in criteria %}
+			<th class="score" style="width: 100px">Score ({{ c.maximum_score }})</th>
+			{% endfor %}
+			<th class="score" style="width: 100px">Score ({{max_total_score}})</th>
+		</tr>
+	</thead>
+	<tbody>
+		{% for s in students %}
+		<tr
+			{% if(s.assessment_details && s.docstatus && s.docstatus == 1) { %} class="text-muted" {% } %}
+			data-student="{{s.student}}">
+
+			<td>{{ s.student }}</td>
+			<td>{{ s.student_name }}</td>
+			{% for c in criteria %}
+			<td class="assessment-criteria" data-criteria-index="{{c._index}}">
+				<span data-student="{{s.student}}" data-criteria="{{c.assessment_criteria}}" class="student-result-grade badge" >
+					{% if(s.assessment_details) { %}
+						{{s.assessment_details[c.assessment_criteria][1]}}
+					{% } %}
+				</span>
+				<input type="number" class="student-result-data" style="width:70%; float:right;"
+					data-max-score="{{c.maximum_score}}"
+					data-criteria="{{c.assessment_criteria}}"
+					data-student="{{s.student}}"
+					{% if(s.assessment_details && s.docstatus && s.docstatus == 1) { %} disabled {% } %}
+					{% if(s.assessment_details) { %}
+						value="{{s.assessment_details[c.assessment_criteria][0]}}"
+					{% } %}/>
+			</td>
+			{% endfor %}
+			<td>
+				<input type="text" class="result-comment" data-student="{{s.student}}"
+				{% if(s.assessment_details && s.docstatus && s.docstatus == 1) { %} disabled {% } %}
+				{% if(s.assessment_details) { %}
+					value="{{s.assessment_details.comment}}"
+				{% } %}
+			</td>
+			<td>
+				<span data-student="{{s.student}}" class="total-score-grade badge" style="width:30%; float:left;">
+				{% if(s.assessment_details) { %}
+				{{s.assessment_details.total_score[1]}}
+				{% } %}
+				</span>
+				<span data-student="{{s.student}}" class="total-score" style="width:60%; float:center;">
+				{% if(s.assessment_details) { %}
+				{{s.assessment_details.total_score[0]}}
+				{% } %}
+				</span>
+				<span data-student="{{s.student}}" class="total-result-link" style="width: 10%; display:{% if(!s.assessment_details) { %}None{% } %}; float:right;">
+					<a class="btn-open no-decoration" title="Open Link" href="/app/Form/Assessment Result/{% if(s.assessment_details) { %}{{s.name}}{% } %}">
+						<i class="octicon octicon-arrow-right"></i>
+					</a>
+				</span>
+			</td>
+			<td>
+				<span data-student="{{s.student}}" class="total-percentage badge">
+				{% if(s.assessment_details && max_total_score) { %}
+				{{ Math.round((s.assessment_details.total_score[0] / max_total_score) * 1000) / 10 }}%
+				{% } %}
+				</span>
+			</td>
+		</tr>
+		{% endfor %}
+	</tbody>
+</table>`;
+
+function nl_percentage(score, max_total) {
+	if (!max_total) return '';
+	return Math.round((score / max_total) * 1000) / 10 + '%';
+}
+
+frappe.ui.form.on('Assessment Result Tool', {
+	onload: function (frm) {
+		frm.set_query('assessment_plan', function () {
+			return {
+				filters: {
+					status: 'Open',
+				},
+			};
+		});
+	},
+
+	// Overrides Education's get_marks: same behaviour, plus the "Out of 100" column.
+	get_marks: function (frm, criteria_list) {
+		let max_total_score = 0;
+		criteria_list.forEach(function (c) {
+			max_total_score += c.maximum_score;
+		});
+
+		var result_table = $(
+			frappe.render_template(NL_ASSESSMENT_RESULT_TEMPLATE, {
+				frm: frm,
+				students: frm.doc.students,
+				criteria: criteria_list,
+				max_total_score: max_total_score,
+			}),
+		);
+		result_table.appendTo(frm.fields_dict.result_html.wrapper);
+
+		$('.assessment-criteria').on('keydown', function (e) {
+			let criteriaIndex = cint(
+				e.target.parentElement.getAttribute('data-criteria-index'),
+			);
+			changeFocusToNextCell(e, 2 + criteriaIndex);
+		});
+
+		$('.result-comment').on('keydown', function (e) {
+			changeFocusToNextCell(e, 5);
+		});
+
+		function changeFocusToNextCell(e, cellIndex) {
+			if (e.keyCode === 13 && !e.shiftKey) {
+				let nextRow =
+					e.target.parentElement.parentElement.nextElementSibling;
+				if (nextRow) {
+					nextRow.cells[cellIndex].lastElementChild.focus();
+				}
+			}
+			if (e.keyCode === 13 && e.shiftKey) {
+				let prevRow =
+					e.target.parentElement.parentElement.previousElementSibling;
+				if (prevRow) {
+					prevRow.cells[cellIndex].lastElementChild.focus();
+				}
+			}
+		}
+
+		result_table.on('change', 'input', function (e) {
+			let $input = $(e.target);
+			let student = $input.data().student;
+			let max_score = $input.data().maxScore;
+			let value = $input.val();
+			if (value < 0) {
+				$input.val(0);
+			} else if (value > max_score) {
+				$input.val(max_score);
+			}
+			let total_score = 0;
+			let student_scores = {};
+			student_scores['assessment_details'] = {};
+			result_table
+				.find(`input[data-student=${student}].student-result-data`)
+				.each(function (el, input) {
+					let $input = $(input);
+					let criteria = $input.data().criteria;
+					let value = parseFloat($input.val());
+					if (!Number.isNaN(value)) {
+						student_scores['assessment_details'][criteria] = value;
+					}
+					total_score += value;
+				});
+			if (!Number.isNaN(total_score)) {
+				result_table
+					.find(`span[data-student=${student}].total-score`)
+					.html(total_score);
+				result_table
+					.find(`span[data-student=${student}].total-percentage`)
+					.html(nl_percentage(total_score, max_total_score));
+			}
+			if (
+				Object.keys(student_scores['assessment_details']).length ===
+				criteria_list.length
+			) {
+				student_scores['student'] = student;
+				student_scores['total_score'] = total_score;
+				result_table
+					.find(`[data-student=${student}].result-comment`)
+					.each(function (el, input) {
+						student_scores['comment'] = $(input).val();
+					});
+				frappe.call({
+					method: 'education.education.api.mark_assessment_result',
+					args: {
+						assessment_plan: frm.doc.assessment_plan,
+						scores: student_scores,
+					},
+					callback: function (r) {
+						let assessment_result = r.message;
+						if (!frm.doc.show_submit) {
+							frm.doc.show_submit = true;
+							frm.events.submit_result;
+						}
+						for (var criteria of Object.keys(
+							assessment_result.details,
+						)) {
+							result_table
+								.find(
+									`[data-criteria=${criteria}][data-student=${assessment_result.student}].student-result-grade`,
+								)
+								.each(function (e1, input) {
+									$(input).html(
+										assessment_result.details[criteria],
+									);
+								});
+						}
+						result_table
+							.find(
+								`span[data-student=${assessment_result.student}].total-score-grade`,
+							)
+							.html(assessment_result.grade);
+						let link_span = result_table.find(
+							`span[data-student=${assessment_result.student}].total-result-link`,
+						);
+						$(link_span).css('display', 'block');
+						$(link_span)
+							.find('a')
+							.attr(
+								'href',
+								'/app/assessment-result/' +
+									assessment_result.name,
+							);
+					},
+				});
+			}
+		});
+	},
 });


### PR DESCRIPTION
This pull request introduces two main enhancements: it adds support for including a letterhead when printing timetable generation results, and it customizes the Assessment Result Tool to display student scores as percentages out of 100. The changes improve both the presentation of printed timetables and the usability of assessment result entry and display.

**Timetable Printing Enhancements:**

* Added an option in the print dialog to select a "Letter Head" (`Letter Head` DocType); the selected letterhead's HTML is fetched and included at the top of the printout. If left blank, no letterhead is shown. The dialog defaults to the site's default letterhead if available. [[1]](diffhunk://#diff-2c6edbbfb4d6e7036ddf3848c712233ef3ec2785195d9e07ac86fd7a986b812bR473-R480) [[2]](diffhunk://#diff-2c6edbbfb4d6e7036ddf3848c712233ef3ec2785195d9e07ac86fd7a986b812bR504-R529)
* Updated the print HTML generators (`generateStandardPrintHtml`, `generateColorPrintHtml`) to render the letterhead HTML (if provided) above the timetable, and added a CSS class for spacing. [[1]](diffhunk://#diff-2c6edbbfb4d6e7036ddf3848c712233ef3ec2785195d9e07ac86fd7a986b812bR285-R288) [[2]](diffhunk://#diff-2c6edbbfb4d6e7036ddf3848c712233ef3ec2785195d9e07ac86fd7a986b812bR405-R408)

**Assessment Result Tool Customization:**

* Replaced the standard assessment result table with a custom template that adds a final column showing each student's total score as a percentage out of 100, improving clarity for educators and students.
* Enhanced the marks entry UI to recalculate and display both the total and percentage as scores are entered, and to handle keyboard navigation between cells for efficient data entry.
* Updated the logic for saving and displaying assessment results to support the new UI and percentage calculations.